### PR TITLE
Fix broken comparison test

### DIFF
--- a/test/compare_generated.jl
+++ b/test/compare_generated.jl
@@ -10,9 +10,9 @@ include("problems.jl")
         split_linear_prob_wfact_split,
         split_linear_prob_wfact_split_fe,
     )
-        integrator = DiffEqBase.init(problem, algorithm; dt)
-        not_generated_integrator = DiffEqBase.init(problem, algorithm; dt)
-    
+        integrator = DiffEqBase.init(deepcopy(problem), algorithm; dt)
+        not_generated_integrator = DiffEqBase.init(deepcopy(problem), algorithm; dt)
+
         integrator.cache = ClimaTimeSteppers.cache(problem, algorithm)
         not_generated_integrator.cache =
             ClimaTimeSteppers.not_generated_cache(problem, algorithm)
@@ -22,6 +22,7 @@ include("problems.jl")
             not_generated_integrator,
             not_generated_integrator.cache,
         )
+        @test !(integrator.u === not_generated_integrator.u)
         @test integrator.u == not_generated_integrator.u
 
         benchmark = @benchmark ClimaTimeSteppers.step_u!(


### PR DESCRIPTION
This PR fixes a broken test (`@test !(integrator.u === not_generated_integrator.u)` was failing), which meant that the comparison was against the same backing data, so the comparison of solutions was not actually valid. Fortunately, the comparison tests are still passing.

I haven't checked, but we should double check that this isn't happening elsewhere (cc @dennisYatunin).