### PR TITLE
Fix bug in IMEXARKAlgorithm, add HOMMEM1

### DIFF
--- a/src/solvers/imex_ark_tableaus.jl
+++ b/src/solvers/imex_ark_tableaus.jl
@@ -1,7 +1,7 @@
 export ARS111, ARS121, ARS122, ARS233, ARS232, ARS222, ARS343, ARS443
 export IMKG232a, IMKG232b, IMKG242a, IMKG242b, IMKG252a, IMKG252b
 export IMKG253a, IMKG253b, IMKG254a, IMKG254b, IMKG254c, IMKG342a, IMKG343a
-export DBM453
+export DBM453, HOMMEM1
 
 using StaticArrays: @SArray, SMatrix, sacollect
 
@@ -150,6 +150,13 @@ const ARS443 = make_IMEXARKAlgorithm(;
 # appear to be wrong, so they are not included here. Eventually, we should get
 # the official implementations from the paper's authors.
 
+# a_exp:                                   a_imp:
+# 0      0      ⋯      0      0      0     0      0      ⋯      0      0      0
+# α[1]   0      ⋱      ⋮      ⋮      ⋮     α̂[1]   δ̂[1]   ⋱      ⋮      ⋮       0
+# β[1]   α[2]   ⋱      0      0      0    β[1]   α̂[2]   ⋱      0      0      0
+# ⋮      0      ⋱      0      0      0     ⋮      0      ⋱      δ̂[s-3] 0      0
+# ⋮      ⋮       ⋱     α[s-2] 0      0     ⋮      ⋮       ⋱      α̂[s-2] δ̂[s-2] 0
+# β[s-2] 0      ⋯      0      α[s-1] 0     β[s-2] 0      ⋯       0      α̂[s-1] 0
 imkg_exp(i, j, α, β) = i == j + 1 ? α[j] : (i > 2 && j == 1 ? β[i - 2] : 0)
 imkg_imp(i, j, α̂, β, δ̂) = i == j + 1 ? α̂[j] :
     (i > 2 && j == 1 ? β[i - 2] : (1 < i <= length(α̂) && i == j ? δ̂[i - 1] : 0))
@@ -317,3 +324,31 @@ const DBM453 = let
         ]),
     )
 end
+
+################################################################################
+
+# HOMMEM1 algorithm
+
+# From Section 4.1 of "A framework to evaluate IMEX schemes for atmospheric
+# models" by Guba et al.
+
+# The algorithm has 5 implicit stages, 6 overall stages, and 2rd order accuracy.
+
+const HOMMEM1 = make_IMEXARKAlgorithm(;
+    a_exp = @SArray([
+        0   0   0   0   0   0;
+        1/5 0   0   0   0   0;
+        0   1/5 0   0   0   0;
+        0   0   1/3 0   0   0;
+        0   0   0   1/2 0   0;
+        0   0   0   0   1   0;
+    ]),
+    a_imp = @SArray([
+        0    0    0    0    0    0;
+        0    1/5  0    0    0    0;
+        0    0    1/5  0    0    0;
+        0    0    0    1/3  0    0;
+        0    0    0    0    1/2  0;
+        5/18 5/18 0    0    0    8/18;
+    ]),
+)

--- a/test/convergence.jl
+++ b/test/convergence.jl
@@ -43,7 +43,7 @@ end
     algs1 = (ARS111, ARS121)
     algs2 = (ARS122, ARS232, ARS222, IMKG232a, IMKG232b, IMKG242a, IMKG242b)
     algs2 = (algs2..., IMKG252a, IMKG252b, IMKG253a, IMKG253b, IMKG254a)
-    algs2 = (algs2..., IMKG254b, IMKG254c)
+    algs2 = (algs2..., IMKG254b, IMKG254c, HOMMEM1)
     algs3 = (ARS233, ARS343, ARS443, IMKG342a, IMKG343a, DBM453)
     for (algorithm_names, order) in ((algs1, 1), (algs2, 2), (algs3, 3))
         for algorithm_name in algorithm_names
@@ -52,12 +52,12 @@ end
                 (split_linear_prob_wfact_split_fe, linear_sol),
             )
                 algorithm = algorithm_name(
-                    NewtonsMethod(; linsolve = linsolve_direct, max_iters = 2),
-                ) # setting max_iters = 1 gives incorrect convergence orders
+                    NewtonsMethod(; linsolve = linsolve_direct, max_iters = 1),
+                ) # the problem is linear, so more iters have no effect
                 @test isapprox(
                     convergence_order(problem, solution, algorithm, dts),
                     order;
-                    atol = 0.02,
+                    rtol = 0.01,
                 )
             end
         end


### PR DESCRIPTION
# PULL REQUEST

## Purpose and Content
This PR fixes a big in the IMEX ARK scheme that was causing the implicit tendency to not be recorded for the last Newton iteration (it was being recorded for the pre-last Newton iteration). It also adds the HOMMEM1 IMEX ARK method, which Oswald asked to have available.

## Benefits and Risks
The linear IMEX unit test now only requires one Newton iteration to give the expected convergence orders, whereas before it required 2 (using more iterations does not change the convergence order, as the problem is linear). This should fix some of the issues we've been seeing in ClimaAtmos.

## PR Checklist
- [ ] This PR has a corresponding issue OR is linked to an SDI.
- [ ] I have followed CliMA's codebase [contribution](https://clima.github.io/ClimateMachine.jl/latest/Contributing/) and [style](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) guidelines OR N/A.
- [ ] I have followed CliMA's [documentation policy](https://github.com/CliMA/policies/wiki/Documentation-Policy).
- [ ] I have checked all issues and PRs and I certify that this PR does not duplicate an open PR.
- [ ] I linted my code on my local machine prior to submission OR N/A.
- [ ] Unit tests are included OR N/A.
- [ ] Code used in an integration test OR N/A.
- [ ] All tests ran successfully on my local machine OR N/A.
- [ ] All classes, modules, and function contain docstrings OR N/A.
- [ ] Documentation has been added/updated OR N/A.
