### PR TITLE
Add print_condition_number option

### DIFF
--- a/docs/src/newtons_method.md
+++ b/docs/src/newtons_method.md
@@ -14,6 +14,8 @@ KrylovMethod
 ForcingTerm
 ConstantForcing
 EisenstatWalkerForcing
+KrylovMethodDebugger
+PrintConditionNumber
 ```
 
 ## Jacobian-free Newton-Krylov Method

--- a/test/test_newtons_method.jl
+++ b/test/test_newtons_method.jl
@@ -10,6 +10,7 @@ function linear_equation(FT, n)
     x_init = zeros(FT, n)
     return (f!, j!, x_exact, x_init)
 end
+
 function nonlinear_equation(FT, n)
     rng = MersenneTwister(1)
     A = rand(rng, FT, n, n)
@@ -65,4 +66,16 @@ end
             @test norm(x .- x_exact) / norm(x_exact) < rtol
         end
     end
+end
+
+@testset "Dense Matrix From Operator" begin
+    n = 10
+    rng = MersenneTwister(1)
+    A = rand(rng, n, n)
+    vector = similar(A, n)
+    matrix = similar(A, n, n)
+    ClimaTimeSteppers.dense_matrix_from_operator!(matrix, vector, A)
+    @test matrix == A
+    ClimaTimeSteppers.dense_inverse_matrix_from_operator!(matrix, vector, lu(A))
+    @test matrix ≈ inv(A)
 end


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
<!--- One sentence to describe the purpose of this PR, refer to any linked issues:
#14 -- this will link to issue 14
Closes #2 -- this will automatically close issue 2 on PR merge
-->
This PR adds a `print_condtion_number` option to `KrylovMethod`.

## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->
When `print_condtion_number` is `true`, the full Jacobian matrix is materialized before any Krylov iterations occur, and its condition number is printed to the terminal. If a preconditioner is being used, the condition numbers with and without the preconditioner are both printed. Note that this process will usually be slower than the Krylov iterations themselves, so `print_condtion_number` should only be set to `true` for debugging.

<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [x] I have read and checked the items on the review checklist.
