### PR TITLE
Rm duplicate type information in SparseContainers

### DIFF
--- a/src/sparse_containers.jl
+++ b/src/sparse_containers.jl
@@ -20,19 +20,24 @@ v = SparseContainer((a1,a2,a3,a4), (1,3,5,7))
 @test v[7] == ones(3) .* 4
 ```
 """
-struct SparseContainer{ET, SIM, T}
+struct SparseContainer{SIM, T}
     data::T
-    function SparseContainer(compressed_data::T, sparse_index_map::Tuple) where {T}
+    function SparseContainer(
+            compressed_data::T,
+            sparse_index_map::Tuple
+        ) where {N, ET, T <: NTuple{N, ET}}
         @assert all(map(x-> eltype(compressed_data) .== typeof(x), compressed_data))
-        return new{eltype(compressed_data), sparse_index_map, T}(compressed_data)
+        return new{sparse_index_map, T}(compressed_data)
     end
 end
 
 Base.parent(sc::SparseContainer) = sc.data
-@inline function Base.getindex(sc::SparseContainer{ET}, i::Int) where {ET}
-    return _getindex_sparse(sc, Val(i))::ET
+sc_eltype(::Type{NTuple{N, T}}) where {N, T} = T
+sc_eltype(::SparseContainer{SIM, T}) where {SIM, T} = sc_eltype(T)
+@inline function Base.getindex(sc::SparseContainer, i::Int)
+    return _getindex_sparse(sc, Val(i))::sc_eltype(sc)
 end
-@generated function _getindex_sparse(sc::SparseContainer{ET,SIM}, ::Val{i})::ET where {ET, SIM, i}
+@generated function _getindex_sparse(sc::SparseContainer{SIM}, ::Val{i}) where {SIM, i}
     j = findfirst(k -> k == i, SIM)
     j == nothing && error("No index $i found in sparse index map $(SIM)")
     return :(sc.data[$j])


### PR DESCRIPTION
This PR removes the duplicate type information in the SparseContainers type by requiring the input is an `NTuple`, and then adding

```julia
sc_eltype(::Type{NTuple{N, T}}) where {N, T} = T
sc_eltype(::SparseContainer{SIM, T}) where {SIM, T} = sc_eltype(T)
```
So that we can still retain the eltype information without explicitly storing it.