### PR TITLE
Prep alleviating latency issues

### DIFF
--- a/src/sparse_containers.jl
+++ b/src/sparse_containers.jl
@@ -25,7 +25,7 @@ struct SparseContainer{SIM, T}
     function SparseContainer(
             compressed_data::T,
             sparse_index_map::Tuple
-        ) where {N, ET, T <: NTuple{N, ET}}
+        ) where {T}
         @assert all(map(x-> eltype(compressed_data) .== typeof(x), compressed_data))
         return new{sparse_index_map, T}(compressed_data)
     end
@@ -33,6 +33,7 @@ end
 
 Base.parent(sc::SparseContainer) = sc.data
 sc_eltype(::Type{NTuple{N, T}}) where {N, T} = T
+sc_eltype(::Type{T}) where {ET, T <: AbstractArray{ET}} = ET
 sc_eltype(::SparseContainer{SIM, T}) where {SIM, T} = sc_eltype(T)
 @inline function Base.getindex(sc::SparseContainer, i::Int)
     return _getindex_sparse(sc, Val(i))::sc_eltype(sc)

--- a/test/sparse_containers.jl
+++ b/test/sparse_containers.jl
@@ -19,4 +19,24 @@ using Test
 
     @test_throws ErrorException("No index 2 found in sparse index map (1, 3, 5, 7)") v[2]
     @test_throws ErrorException("No index 8 found in sparse index map (1, 3, 5, 7)") v[8]
+    @inferred v[7]
+
+    a1 = ones(3) .* 1
+    a2 = ones(3) .* 2
+    a3 = ones(3) .* 3
+    a4 = ones(3) .* 4
+    v = SparseContainer([a1,a2,a3,a4], (1,3,5,7))
+    @test v[1] == ones(3) .* 1
+    @test v[3] == ones(3) .* 2
+    @test v[5] == ones(3) .* 3
+    @test v[7] == ones(3) .* 4
+
+    @test parent(v)[1] == ones(3) .* 1
+    @test parent(v)[2] == ones(3) .* 2
+    @test parent(v)[3] == ones(3) .* 3
+    @test parent(v)[4] == ones(3) .* 4
+
+    @test_throws ErrorException("No index 2 found in sparse index map (1, 3, 5, 7)") v[2]
+    @test_throws ErrorException("No index 8 found in sparse index map (1, 3, 5, 7)") v[8]
+    @inferred v[7]
 end


### PR DESCRIPTION
This PR takes a couple steps to tackle some latency issues:
 - [Avoid UnionAll::DataType in struct](https://github.com/CliMA/ClimaTimeSteppers.jl/commit/52c9ff0cd6c1dc10271023811e626300a1109937), which was shown to improve inference [here](https://github.com/CliMA/Thermodynamics.jl/pull/71), and a smaller MWE [here](https://gist.github.com/charleskawczynski/61efc7b769e14eab7231e686773b9d0e)
 - [Allow SparseContainers to work with Arrays](https://github.com/CliMA/ClimaTimeSteppers.jl/commit/c5c53ee37e950384b4cac1b9c11335e76609192a)