### PR TITLE
Move callbacks test into safetestset

### DIFF
--- a/test/callbacks.jl
+++ b/test/callbacks.jl
@@ -40,6 +40,10 @@ cbs = CallbackSet(
     EveryXWallTimeSeconds(cb5, 0.49, comm_ctx)
 )
 
+const_prob_inc = ODEProblem(
+    IncrementingODEFunction{true}((du,u,p,t,α=true,β=false) -> (du .= α .* p .+ β .* du)),
+    [0.0],(0.0,1.0),2.0)
+
 solve(const_prob_inc, LSRKEulerMethod(), dt=1/32, callback=cbs)
 
 @test cb1.initialized

--- a/test/problems.jl
+++ b/test/problems.jl
@@ -4,17 +4,6 @@ if !@isdefined(ArrayType)
     ArrayType = Array
 end
 
-const_prob = ODEProblem((du,u,p,t) -> (du .= p),[0.0],(0.0,1.0),2.0)
-const_prob_inc = ODEProblem(
-    IncrementingODEFunction{true}((du,u,p,t,α=true,β=false) -> (du .= α .* p .+ β .* du)),
-    [0.0],(0.0,1.0),2.0)
-const_prob_fe = ODEProblem(
-        ForwardEulerODEFunction((un,u,p,t,dt) -> (un .= u .+ dt.* p)),
-        [0.0],(0.0,1.0),2.0)
-const_sol(t) = [0.0 .+ 2.0 * t]
-
-
-
 """
 Single variable linear ODE
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -9,6 +9,7 @@ end
 @safetestset "SparseContainers" begin include("sparse_containers.jl") end
 @safetestset "Newtons method" begin include("test_newtons_method.jl") end
 @safetestset "Single column ARS" begin include("single_column_ARS_test.jl") end
+@safetestset "Callbacks" begin include("callbacks.jl") end
 @safetestset "Aqua" begin include("aqua.jl") end
 
 include("problems.jl")
@@ -16,6 +17,5 @@ include("utils.jl")
 
 include("integrator.jl")
 include("convergence.jl")
-include("callbacks.jl")
 include("test_convergence_checker.jl")
 include("compare_generated.jl") # TODO: Remove this.


### PR DESCRIPTION
This PR:
 - Deletes unused variables
 - Moves the `const_prob_inc` problem into `test/callbacks.jl`
 - Moves the callbacks test into a SafeTestsets test, to improve test modularity