### PR TITLE
Modularize remaining unit tests

### DIFF
--- a/docs/src/algorithms.md
+++ b/docs/src/algorithms.md
@@ -25,8 +25,6 @@ The convergence orders of the provided methods are verified using test cases fro
 using Pkg
 Pkg.activate("../../test")
 Pkg.instantiate()
-include("../../test/problems.jl")
-include("../../test/utils.jl")
 include("../../test/convergence.jl")
 Pkg.activate(".")
 ```

--- a/perf/flame.jl
+++ b/perf/flame.jl
@@ -24,9 +24,9 @@ function do_work!(integrator, not_generated_cache)
 end
 problem_str = parsed_args["problem"]
 prob = if problem_str=="ode_fun"
-    split_linear_prob_wfact_split
+    split_linear_prob_wfact_split()
 elseif problem_str=="fe"
-    split_linear_prob_wfact_split_fe
+    split_linear_prob_wfact_split_fe()
 else
     error("Bad option")
 end

--- a/perf/jet.jl
+++ b/perf/jet.jl
@@ -24,9 +24,9 @@ function config_integrators(problem)
     return (; integrator_generated=integrator, not_generated_integrator)
 end
 prob = if parsed_args["problem"]=="ode_fun"
-    split_linear_prob_wfact_split
+    split_linear_prob_wfact_split()
 elseif parsed_args["problem"]=="fe"
-    split_linear_prob_wfact_split_fe
+    split_linear_prob_wfact_split_fe()
 else
     error("Bad option")
 end

--- a/test/compare_generated.jl
+++ b/test/compare_generated.jl
@@ -6,8 +6,8 @@ include("problems.jl")
     algorithm = ARS343(NewtonsMethod(; max_iters = 2))
     dt = 0.01
     for problem in (
-        split_linear_prob_wfact_split,
-        split_linear_prob_wfact_split_fe,
+        split_linear_prob_wfact_split(),
+        split_linear_prob_wfact_split_fe(),
     )
         integrator = DiffEqBase.init(deepcopy(problem), algorithm; dt)
         not_generated_integrator = deepcopy(integrator)

--- a/test/convergence.jl
+++ b/test/convergence.jl
@@ -1,40 +1,46 @@
 using ClimaTimeSteppers, LinearAlgebra, Test
 
-dts = 0.5 .^ (4:7)
+include(joinpath(@__DIR__, "convergence_utils.jl"))
+include(joinpath(@__DIR__, "utils.jl"))
+include(joinpath(@__DIR__, "problems.jl"))
 
-for (prob, sol, tscale) in [
-    (linear_prob, linear_sol, 1)
-    (sincos_prob, sincos_sol, 1)
-]
+@testset "LSRK and SSP convergence" begin
+    dts = 0.5 .^ (4:7)
 
-    @test convergence_order(prob, sol, LSRKEulerMethod(), dts.*tscale)     ≈ 1 atol=0.1
-    @test convergence_order(prob, sol, LSRK54CarpenterKennedy(), dts.*tscale)       ≈ 4 atol=0.05
-    @test convergence_order(prob, sol, LSRK144NiegemannDiehlBusch(),  dts.*tscale)   ≈ 4 atol=0.05
+    for (prob, sol, tscale) in [
+        (linear_prob(), linear_sol, 1)
+        (sincos_prob(), sincos_sol, 1)
+    ]
 
-    @test convergence_order(prob, sol, SSPRK22Heuns(), dts.*tscale)                 ≈ 2 atol=0.05
-    @test convergence_order(prob, sol, SSPRK22Ralstons(), dts.*tscale)              ≈ 2 atol=0.05
-    @test convergence_order(prob, sol, SSPRK33ShuOsher(), dts.*tscale)              ≈ 3 atol=0.05
-    @test convergence_order(prob, sol, SSPRK34SpiteriRuuth(), dts.*tscale)          ≈ 3 atol=0.05
-end
+        @test convergence_order(prob, sol, LSRKEulerMethod(), dts.*tscale)     ≈ 1 atol=0.1
+        @test convergence_order(prob, sol, LSRK54CarpenterKennedy(), dts.*tscale)       ≈ 4 atol=0.05
+        @test convergence_order(prob, sol, LSRK144NiegemannDiehlBusch(),  dts.*tscale)   ≈ 4 atol=0.05
 
-for (prob, sol, tscale) in [
-    (linear_prob_wfactt, linear_sol, 1)
-]
-    @test convergence_order(prob, sol, SSPKnoth(linsolve=linsolve_direct), dts.*tscale) ≈ 2 atol=0.05
+        @test convergence_order(prob, sol, SSPRK22Heuns(), dts.*tscale)                 ≈ 2 atol=0.05
+        @test convergence_order(prob, sol, SSPRK22Ralstons(), dts.*tscale)              ≈ 2 atol=0.05
+        @test convergence_order(prob, sol, SSPRK33ShuOsher(), dts.*tscale)              ≈ 3 atol=0.05
+        @test convergence_order(prob, sol, SSPRK34SpiteriRuuth(), dts.*tscale)          ≈ 3 atol=0.05
+    end
 
-end
+    for (prob, sol, tscale) in [
+        (linear_prob_wfactt(), linear_sol, 1)
+    ]
+        @test convergence_order(prob, sol, SSPKnoth(linsolve=linsolve_direct), dts.*tscale) ≈ 2 atol=0.05
+
+    end
 
 
-# ForwardEulerODEFunction
-for (prob, sol, tscale) in [
-    (linear_prob_fe, linear_sol, 1)
-    (sincos_prob_fe, sincos_sol, 1)
-]
-    @test convergence_order(prob, sol, SSPRK22Heuns(), dts.*tscale)                 ≈ 2 atol=0.05
-    @test convergence_order(prob, sol, SSPRK22Ralstons(), dts.*tscale)              ≈ 2 atol=0.05
-    @test convergence_order(prob, sol, SSPRK33ShuOsher(), dts.*tscale)              ≈ 3 atol=0.05
-    @test convergence_order(prob, sol, SSPRK34SpiteriRuuth(), dts.*tscale)          ≈ 3 atol=0.05
+    # ForwardEulerODEFunction
+    for (prob, sol, tscale) in [
+        (linear_prob_fe(), linear_sol, 1)
+        (sincos_prob_fe(), sincos_sol, 1)
+    ]
+        @test convergence_order(prob, sol, SSPRK22Heuns(), dts.*tscale)                 ≈ 2 atol=0.05
+        @test convergence_order(prob, sol, SSPRK22Ralstons(), dts.*tscale)              ≈ 2 atol=0.05
+        @test convergence_order(prob, sol, SSPRK33ShuOsher(), dts.*tscale)              ≈ 3 atol=0.05
+        @test convergence_order(prob, sol, SSPRK34SpiteriRuuth(), dts.*tscale)          ≈ 3 atol=0.05
 
+    end
 end
 
 ENV["GKSwstype"] = "nul" # avoid displaying plots
@@ -46,14 +52,14 @@ ENV["GKSwstype"] = "nul" # avoid displaying plots
     algs2 = (algs2..., IMKG254b, IMKG254c, HOMMEM1)
     algs3 = (ARS233, ARS343, ARS443, IMKG342a, IMKG343a, DBM453)
     dict = Dict(((algs1 .=> 1)..., (algs2 .=> 2)..., (algs3 .=> 3)...))
-    test_algs("IMEX ARK", dict, ark_analytic_nonlin_test, 400)
-    test_algs("IMEX ARK", dict, ark_analytic_sys_test, 60)
+    test_algs("IMEX ARK", dict, ark_analytic_nonlin_test(Float64), 400)
+    test_algs("IMEX ARK", dict, ark_analytic_sys_test(Float64), 60)
 
     # For some bizarre reason, ARS121 converges with order 2 for ark_analytic,
     # even though it is only a 1st order method.
     dict′ = copy(dict)
     dict′[ARS121] = 2
-    test_algs("IMEX ARK", dict′, ark_analytic_test, 16000)
+    test_algs("IMEX ARK", dict′, ark_analytic_test(Float64), 16000)
 end
 
 #=

--- a/test/convergence_utils.jl
+++ b/test/convergence_utils.jl
@@ -1,0 +1,49 @@
+
+"""
+    DirectSolver
+
+A linear solver which forms the full matrix of a linear operator and its LU factorization.
+"""
+struct DirectSolver end
+
+DirectSolver(args...) = DirectSolver()
+
+function (::DirectSolver)(x,A,b,matrix_updated; kwargs...)
+  n = length(x)
+  M = mapslices(y -> mul!(similar(y), A, y), Matrix{eltype(x)}(I,n,n), dims=1)
+  x .= M \ b
+end
+
+"""
+    convergence_rates(problem, solution, method, dts; kwargs...)
+
+Compute the errors rates of `method` on `problem` by comparing to `solution`
+on the set of `dt` values in `dts`. Extra `kwargs` are passed to `solve`
+
+`solution` should be a function with a method `solution(u0, p, t)`.
+"""
+function convergence_errors(prob, sol, method, dts; kwargs...)
+  errs = map(dts) do dt
+       # copy the problem so we don't mutate u0
+      prob_copy = deepcopy(prob)
+      u = solve(prob_copy, method; dt=dt, saveat=(prob.tspan[2],), kwargs...)
+      norm(u .- sol(prob.u0, prob.p, prob.tspan[end]))
+  end
+  return errs
+end
+
+
+"""
+  convergence_order(problem, solution, method, dts; kwargs...)
+
+Estimate the order of the rate of convergence of `method` on `problem` by comparing to
+`solution` the set of `dt` values in `dts`.
+
+`solution` should be a function with a method `solution(u0, p, t)`.
+"""
+function convergence_order(prob, sol, method, dts; kwargs...)
+  errs = convergence_errors(prob, sol, method, dts; kwargs...)
+  # find slope coefficient in log scale
+  _,order_est = hcat(ones(length(dts)), log2.(dts)) \ log2.(errs)
+  return order_est
+end

--- a/test/integrator.jl
+++ b/test/integrator.jl
@@ -4,7 +4,7 @@ import OrdinaryDiffEq
 include("problems.jl")
 
 @testset "integrator save times" begin
-    test_case = constant_tendency_test
+    test_case = constant_tendency_test(Float64)
     (; prob, analytic_sol) = test_case
     for alg in (SSPRK33ShuOsher(), OrdinaryDiffEq.SSPRK33()),
         reverse_prob in (false, true),
@@ -121,7 +121,7 @@ end
     # OrdinaryDiffEq does not save at t0′ after reinit! unless erase_sol is
     # true, so this test does not include a comparison with OrdinaryDiffEq.
     alg = SSPRK33ShuOsher()
-    test_case = constant_tendency_test
+    test_case = constant_tendency_test(Float64)
     (; prob, analytic_sol) = test_case
     for reverse_prob in (false, true)
         if reverse_prob
@@ -161,7 +161,7 @@ end
 
 @testset "integrator step past end time" begin
     alg = SSPRK33ShuOsher()
-    test_case = constant_tendency_test
+    test_case = constant_tendency_test(Float64)
     (; prob, analytic_sol) = test_case
     t0, tf = prob.tspan
     dt = tf - t0

--- a/test/problems.jl
+++ b/test/problems.jl
@@ -1,9 +1,5 @@
 using DiffEqBase, ClimaTimeSteppers, LinearAlgebra, StaticArrays
 
-if !@isdefined(ArrayType)
-    ArrayType = Array
-end
-
 """
 Single variable linear ODE
 
@@ -17,22 +13,29 @@ u(t) = u_0 e^{αt}
 
 This is an in-place variant of the one from DiffEqProblemLibrary.jl.
 """
-linear_prob = ODEProblem(
+function linear_prob()
+    ODEProblem(
     IncrementingODEFunction{true}((du,u,p,t,α=true,β=false) -> (du .= α .* p .* u .+ β .* du)),
     [1/2],(0.0,1.0),1.01)
-linear_prob_fe = ODEProblem(
+end
+function linear_prob_fe()
+    ODEProblem(
     ForwardEulerODEFunction((un,u,p,t,dt) -> (un .= u .+ dt .* p .* u)),
     [1.0],(0.0,1.0),-0.2)
+end
 
-linear_prob_wfactt = ODEProblem(
+function linear_prob_wfactt()
+    ODEProblem(
         ODEFunction(
           (du,u,p,t) -> (du .= p .* u);
           jac_prototype=zeros(1,1),
           Wfact_t = (W,u,p,γ,t) -> (W[1,1]=1/γ-p),
         ),
         [1/2],(0.0,1.0),-0.2)
+end
 
-split_linear_prob_wfact_split = ODEProblem(
+function split_linear_prob_wfact_split()
+    ODEProblem(
     SplitFunction(
         ODEFunction(
             (du,u,p,t) -> (du .= real(p) .* u);
@@ -42,8 +45,10 @@ split_linear_prob_wfact_split = ODEProblem(
         ODEFunction((du, u, p, t) -> (du .= imag(p) * im .* u)),
     ),
     [1/2 + 0.0*im],(0.0,1.0),-0.2+0.1*im)
+end
 
-split_linear_prob_wfact_split_fe = ODEProblem(
+function split_linear_prob_wfact_split_fe()
+    ODEProblem(
     SplitFunction(
         ODEFunction(
             (du,u,p,t) -> (du .= real(p) .* u);
@@ -55,7 +60,7 @@ split_linear_prob_wfact_split_fe = ODEProblem(
         ),
     ),
     [1/2 + 0.0*im],(0.0,1.0),-0.2+0.1*im)
-
+end
 
 # DiffEqProblemLibrary.jl uses the `analytic` argument to ODEFunction to store the exact solution
 # IncrementingODEFunction doesn't have that
@@ -75,12 +80,16 @@ with initial condition ``u_0=[0,1]``, parameter ``α=2``, and solution
 u(t) = [cos(αt) sin(αt); -sin(αt) cos(αt) ] u_0
 ```
 """
-sincos_prob = ODEProblem(
+function sincos_prob()
+    ODEProblem(
     IncrementingODEFunction{true}((du,u,p,t,α=true,β=false) -> (du[1] = α*p*u[2]+β*du[1]; du[2] = -α*p*u[1]+β*du[2])),
     [0.0,1.0], (0.0,1.0), 2.0)
-sincos_prob_fe = ODEProblem(
+end
+function sincos_prob_fe()
+    ODEProblem(
     ForwardEulerODEFunction((un,u,p,t,dt) -> (un[1] = u[1] + dt*p*u[2]; un[2] = u[2]-dt*p*u[1])),
     [0.0,1.0], (0.0,1.0), 2.0)
+end
 
 function sincos_sol(u0,p,t)
     s,c = sincos(p*t)
@@ -98,10 +107,12 @@ with initial condition ``u_0 = 1/2``, parameter ``α=4``, and solution
 u(t) = \frac{e^t + sin(t) - cos(t)}{2 α} + u_0 e^t
 ```
 """
-imex_autonomous_prob = SplitODEProblem(
+function imex_autonomous_prob(::Type{ArrayType}) where {ArrayType}
+    SplitODEProblem(
     IncrementingODEFunction{true}((du, u, p, t, α=true, β=false) -> (du .= α .* u        .+ β .* du)),
     IncrementingODEFunction{true}((du, u, p, t, α=true, β=false) -> (du .= α .* cos(t)/p .+ β .* du)),
     ArrayType([0.5]), (0.0,1.0), 4.0)
+end
 
 function linsolve_direct(::Type{Val{:init}}, f, u0; kwargs...)
     function _linsolve!(x, A, b, update_matrix = false; kwargs...)
@@ -109,48 +120,30 @@ function linsolve_direct(::Type{Val{:init}}, f, u0; kwargs...)
     end
 end
 
-imex_autonomous_prob_jac = ODEProblem(
+function imex_autonomous_prob_jac(::Type{ArrayType}) where {ArrayType}
+    ODEProblem(
         ODEFunction(
             IncrementingODEFunction{true}((du, u, p, t, α=true, β=false) -> (du .= α .* (u .+ cos(t)/p) .+ β .* du)),
             jac_prototype = zeros(1,1),
             Wfact = (W,u,p,γ,t) -> W[1,1] = 1-γ,
         ),
         ArrayType([0.5]), (0.0,1.0), 4.0)
+end
 
 function imex_autonomous_sol(u0,p,t)
     (exp(t)  + sin(t) - cos(t)) / 2p .+ exp(t) .* u0
 end
 
-imex_nonautonomous_prob = SplitODEProblem(
+function imex_nonautonomous_prob(::Type{ArrayType}) where {ArrayType}
+    SplitODEProblem(
     IncrementingODEFunction{true}((du, u, p, t, α=true, β=false) -> (du .= α .* cos(t) * u .+ β .* du)),
     IncrementingODEFunction{true}((du, u, p, t, α=true, β=false) -> (du .= α .* cos(t)/p   .+ β .* du)),
     ArrayType([0.5]), (0.0,2.0), 4.0)
+end
 
 function imex_nonautonomous_sol(u0,p,t)
     (exp(sin(t)) .* (1 .+ p .* u0) .- 1) ./ p
 end
-
-
-"""
-Test problem (4.2) from RobertsSarsharSandu2018arxiv
-@article{RobertsSarsharSandu2018arxiv,
-    title={Coupled Multirate Infinitesimal GARK Schemes for Stiff Systems with
-            Multiple Time Scales},
-    author={Roberts, Steven and Sarshar, Arash and Sandu, Adrian},
-    journal={arXiv preprint arXiv:1812.00808},
-    year={2019}
-}
-
-Note: The actual rates are all over the place with this test and passing largely
-        depends on final dt size
-"""
-kpr_param = (
-    ω = 100,
-    λf = -10,
-    λs = -1,
-    ξ = 0.1,
-    α = 1,
-)
 
 function kpr_rhs(Q,param,t)
     yf, ys = Q
@@ -195,16 +188,52 @@ function kpr_sol(u0,param,t)
     ]
 end
 
-kpr_multirate_prob = SplitODEProblem(
-    IncrementingODEFunction{true}(kpr_fast!),
-    IncrementingODEFunction{true}(kpr_slow!),
-    [sqrt(4), sqrt(3)], (0.0, 5π/2), kpr_param,
-)
+"""
+Test problem (4.2) from RobertsSarsharSandu2018arxiv
 
-kpr_singlerate_prob = ODEProblem(
-    IncrementingODEFunction{true}((dQ,Q,param,t,α=1,β=0) -> (dQ .= α .* kpr_rhs(Q,param,t) .+ β .* dQ)),
-    [sqrt(4), sqrt(3)], (0.0, 5π/2), kpr_param,
-)
+# TODO: move this to bibliography
+
+```
+@article{RobertsSarsharSandu2018arxiv,
+    title={Coupled Multirate Infinitesimal GARK Schemes for Stiff Systems with
+            Multiple Time Scales},
+    author={Roberts, Steven and Sarshar, Arash and Sandu, Adrian},
+    journal={arXiv preprint arXiv:1812.00808},
+    year={2019}
+}
+```
+
+Note: The actual rates are all over the place with this test and passing largely
+        depends on final dt size
+"""
+function kpr_multirate_prob()
+    kpr_param = (
+        ω = 100,
+        λf = -10,
+        λs = -1,
+        ξ = 0.1,
+        α = 1,
+    )
+    SplitODEProblem(
+        IncrementingODEFunction{true}(kpr_fast!),
+        IncrementingODEFunction{true}(kpr_slow!),
+        [sqrt(4), sqrt(3)], (0.0, 5π/2), kpr_param,
+    )
+end
+
+function kpr_singlerate_prob()
+    kpr_param = (
+        ω = 100,
+        λf = -10,
+        λs = -1,
+        ξ = 0.1,
+        α = 1,
+    )
+    ODEProblem(
+        IncrementingODEFunction{true}((dQ,Q,param,t,α=1,β=0) -> (dQ .= α .* kpr_rhs(Q,param,t) .+ β .* dQ)),
+        [sqrt(4), sqrt(3)], (0.0, 5π/2), kpr_param,
+    )
+end
 
 reverse_problem(prob, analytic_sol) =
     ODEProblem(prob.f, analytic_sol(prob.tspan[2]), reverse(prob.tspan), prob.p)
@@ -272,8 +301,7 @@ function IntegratorTestCase(;
 end
 
 # A trivial test case for which any value of dt will work
-constant_tendency_test = let 
-    FT = Float64
+function constant_tendency_test(::Type{FT}) where {FT}
     tendency = FT[1, 2, 3]
     IntegratorTestCase(;
         test_name = "constant_tendency",
@@ -288,8 +316,7 @@ constant_tendency_test = let
 end
 
 # From Section 1.1 of "Example Programs for ARKode v4.4.0" by D. R. Reynolds
-ark_analytic_test = let
-    FT = Float64
+function ark_analytic_test(::Type{FT}) where {FT}
     λ = FT(-100) # increase magnitude for more stiffness
     source(t) = 1 / (1 + t^2) - λ * atan(t)
     IntegratorTestCase(;
@@ -311,8 +338,7 @@ ark_analytic_test = let
 end
 
 # From Section 1.2 of "Example Programs for ARKode v4.4.0" by D. R. Reynolds
-ark_analytic_nonlin_test = let
-    FT = Float64
+function ark_analytic_nonlin_test(::Type{FT}) where {FT}
     IntegratorTestCase(;
         test_name = "ark_analytic_nonlin",
         linear_implicit = false,
@@ -327,8 +353,7 @@ ark_analytic_nonlin_test = let
 end
 
 # From Section 5.1 of "Example Programs for ARKode v4.4.0" by D. R. Reynolds
-ark_analytic_sys_test = let
-    FT = Float64
+function ark_analytic_sys_test(::Type{FT}) where {FT}
     λ = FT(-100) # increase magnitude for more stiffness
     V = FT[1 -1 1; -1 2 1; 0 -1 2]
     V⁻¹ = FT[5 1 -3; 2 2 -2; 1 1 1] / 4

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,21 +1,22 @@
 using SafeTestsets
+
+#=
+TODO: add separate GPU tests
 if get(ARGS,1,"Array") == "CuArray"
     using CUDA
     const ArrayType = CUDA.CuArray
 else
     const ArrayType = Array
 end
+=#
 
 @safetestset "SparseContainers" begin include("sparse_containers.jl") end
 @safetestset "Newtons method" begin include("test_newtons_method.jl") end
 @safetestset "Single column ARS" begin include("single_column_ARS_test.jl") end
 @safetestset "Callbacks" begin include("callbacks.jl") end
 @safetestset "Aqua" begin include("aqua.jl") end
-
-include("problems.jl")
-include("utils.jl")
-
-include("integrator.jl")
-include("convergence.jl")
-include("test_convergence_checker.jl")
-include("compare_generated.jl") # TODO: Remove this.
+@safetestset "Integrator tests" begin include("integrator.jl") end
+@safetestset "Algorithm convergence" begin include("convergence.jl") end
+@safetestset "Convergence checker unit tests" begin include("test_convergence_checker.jl") end
+ # TODO: Remove this.
+@safetestset "Compare generated and non-generated ARK" begin include("compare_generated.jl") end

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -1,55 +1,5 @@
-using Test, Plots, Printf
-
-"""
-    convergence_rates(problem, solution, method, dts; kwargs...)
-
-Compute the errors rates of `method` on `problem` by comparing to `solution`
-on the set of `dt` values in `dts`. Extra `kwargs` are passed to `solve`
-
-`solution` should be a function with a method `solution(u0, p, t)`.
-"""
-function convergence_errors(prob, sol, method, dts; kwargs...)
-  errs = map(dts) do dt
-       # copy the problem so we don't mutate u0
-      prob_copy = deepcopy(prob)
-      u = solve(prob_copy, method; dt=dt, saveat=(prob.tspan[2],), kwargs...)
-      norm(u .- sol(prob.u0, prob.p, prob.tspan[end]))
-  end
-  return errs
-end
-
-
-"""
-  convergence_order(problem, solution, method, dts; kwargs...)
-
-Estimate the order of the rate of convergence of `method` on `problem` by comparing to
-`solution` the set of `dt` values in `dts`.
-
-`solution` should be a function with a method `solution(u0, p, t)`.
-"""
-function convergence_order(prob, sol, method, dts; kwargs...)
-  errs = convergence_errors(prob, sol, method, dts; kwargs...)
-  # find slope coefficient in log scale
-  _,order_est = hcat(ones(length(dts)), log2.(dts)) \ log2.(errs)
-  return order_est
-end
-
-
-
-"""
-    DirectSolver
-
-A linear solver which forms the full matrix of a linear operator and its LU factorization.
-"""
-struct DirectSolver end
-
-DirectSolver(args...) = DirectSolver()
-
-function (::DirectSolver)(x,A,b,matrix_updated; kwargs...)
-  n = length(x)
-  M = mapslices(y -> mul!(similar(y), A, y), Matrix{eltype(x)}(I,n,n), dims=1)
-  x .= M \ b
-end
+import Plots, Printf
+using Test
 
 """
     test_algs(
@@ -104,16 +54,16 @@ function test_algs(
 
     plot1_dt = t_end / num_steps
     plot1_saveat = 0:(plot1_dt * save_every_n_steps):t_end
-    plot1a = plot(;
+    plot1a = Plots.plot(;
         title = "Solution Norms of $algs_name Methods for `$test_name` \
-                 (with dt = 10^$(@sprintf "%.1f" log10(plot1_dt)))",
+                 (with dt = 10^$(Printf.@sprintf "%.1f" log10(plot1_dt)))",
         xlabel = "t",
         ylabel = "Solution Norm: ||Y_computed||",
         plot_kwargs...,
     )
-    plot1b = plot(;
+    plot1b = Plots.plot(;
         title = "Solution Errors of $algs_name Methods for `$test_name` \
-                 (with dt = 10^$(@sprintf "%.1f" log10(plot1_dt)))",
+                 (with dt = 10^$(Printf.@sprintf "%.1f" log10(plot1_dt)))",
         xlabel = "t",
         ylabel = "Error Norm: ||Y_computed - Y_analytic||",
         yscale = :log10,
@@ -122,9 +72,9 @@ function test_algs(
     plot1b_ymin = typemax(FT) # dynamically set ylim because some errors are 0
     plot1b_ymax = typemin(FT)
 
-    t_end_string = t_end % 1 == 0 ? string(Int(t_end)) : @sprintf("%.2f", t_end)
+    t_end_string = t_end % 1 == 0 ? string(Int(t_end)) : Printf.@sprintf("%.2f", t_end)
     plot2_dts = [plot1_dt / sqrt(10), plot1_dt, plot1_dt * sqrt(10)]
-    plot2 = plot(;
+    plot2 = Plots.plot(;
         title = "Convergence Orders of $algs_name Methods for `$test_name` \
                  (at t = $t_end_string)",
         xlabel = "dt",
@@ -164,8 +114,8 @@ function test_algs(
         plot1b_ymax = max(plot1b_ymax, maximum(tendency_errs))
         tendency_errs .=
             max.(tendency_errs, eps(FT(0))) # plotting 0 breaks the log scale
-        plot!(plot1a, plot1_saveat, tendency_norms; label = alg_name, linestyle)
-        plot!(plot1b, plot1_saveat, tendency_errs; label = alg_name, linestyle)
+        Plots.plot!(plot1a, plot1_saveat, tendency_norms; label = alg_name, linestyle)
+        Plots.plot!(plot1b, plot1_saveat, tendency_errs; label = alg_name, linestyle)
 
         if !(alg_name in no_increment_algs)
             increment_sols =
@@ -181,14 +131,14 @@ function test_algs(
         _, computed_order = hcat(ones(length(plot2_dts)), log10.(plot2_dts)) \
             log10.(tendency_end_errs)
         @test computed_order ≈ predicted_order rtol = 0.1
-        label = "$alg_name ($(@sprintf "%.3f" computed_order))"
-        plot!(plot2, plot2_dts, tendency_end_errs; label, linestyle)
+        label = "$alg_name ($(Printf.@sprintf "%.3f" computed_order))"
+        Plots.plot!(plot2, plot2_dts, tendency_end_errs; label, linestyle)
     end
-    plot!(plot1b; ylim = (plot1b_ymin / 2, plot1b_ymax * 2))
+    Plots.plot!(plot1b; ylim = (plot1b_ymin / 2, plot1b_ymax * 2))
 
     mkpath("output")
     file_suffix = "$(test_name)_$(lowercase(replace(algs_name, " " => "_")))"
-    savefig(plot1a, joinpath("output", "solutions_$(file_suffix).png"))
-    savefig(plot1b, joinpath("output", "errors_$(file_suffix).png"))
-    savefig(plot2, joinpath("output", "orders_$(file_suffix).png"))
+    Plots.savefig(plot1a, joinpath("output", "solutions_$(file_suffix).png"))
+    Plots.savefig(plot1b, joinpath("output", "errors_$(file_suffix).png"))
+    Plots.savefig(plot2, joinpath("output", "orders_$(file_suffix).png"))
 end


### PR DESCRIPTION
This PR:
 - Changes the `test/problems.jl` script to instead define functions
 - Qualifies some methods
 - Moves more tests into safetestsets
 - Includes the utility functions only in the portion of the unit tests where needed.