### PR TITLE
Fix MPI config

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -9,19 +9,25 @@ steps:
   - label: "init cpu env"
     key: "init_cpu_env"
     command:
-      - "echo $JULIA_DEPOT_PATH"
+      - echo "--- Configure MPI"
+      - julia -e 'using Pkg; Pkg.add("MPIPreferences"); using MPIPreferences; use_system_binary()'
+
       - echo "--- Instantiate project"
       - "julia --project -e 'using Pkg; Pkg.instantiate(;verbose=true)'"
       - "julia --project -e 'using Pkg; Pkg.precompile(;strict=true)'"
+
       - echo "--- Instantiate test"
       - "julia --project=test -e 'using Pkg; Pkg.develop(path=\".\")'"
       - "julia --project=test -e 'using Pkg; Pkg.instantiate(;verbose=true)'"
       - "julia --project=test -e 'using Pkg; Pkg.precompile(;strict=true)'"
+
       - echo "--- Instantiate perf"
       - "julia --project=perf -e 'using Pkg; Pkg.instantiate(;verbose=true)'"
       - "julia --project=perf -e 'using Pkg; Pkg.precompile(;strict=true)'"
+
       - echo "--- Package status"
       - "julia --project -e 'using Pkg; Pkg.status()'"
+
     agents:
       config: cpu
       queue: central
@@ -30,17 +36,22 @@ steps:
   - label: "init gpu env"
     key: "init_gpu_env"
     command:
-      - "echo $JULIA_DEPOT_PATH"
+      - echo "--- Configure MPI"
+      - julia -e 'using Pkg; Pkg.add("MPIPreferences"); using MPIPreferences; use_system_binary()'
+
       - echo "--- Instantiate project"
       - "julia --project -e 'using Pkg; Pkg.instantiate(;verbose=true)'"
       - "julia --project -e 'using Pkg; Pkg.precompile(;strict=true)'"
+
       - echo "--- Instantiate test"
       - "julia --project=test -e 'using Pkg; Pkg.develop(path=\".\")'"
       - "julia --project=test -e 'using Pkg; Pkg.instantiate(;verbose=true)'"
       - "julia --project=test -e 'using Pkg; Pkg.precompile()'"
+
       - echo "--- Initialize CUDA runtime"
       - "julia --project -e 'using CUDA; CUDA.precompile_runtime()'"
       - "julia --project -e 'using CUDA; CUDA.versioninfo()'"
+
       - echo "--- Package status"
       - "julia --project -e 'using Pkg; Pkg.status()'"
     agents:


### PR DESCRIPTION
I noticed a deprecation warning:

```
┌ Warning: The JULIA_MPI_BINARY environment variable is no longer used to configure the MPI binary.
│ Please use the MPIPreferences.jl package instead:
│ 
│     MPIPreferences.use_system_binary()  # use the system binary
│     MPIPreferences.use_jll_binary()     # use JLL binary
│ 
│ See https://juliaparallel.org/MPI.jl/stable/configuration/ for more details
│ 
│   ENV["JULIA_MPI_BINARY"] = "system"
│   MPIPreferences.binary = "MPICH_jll"
└ @ MPI /central/scratch/esm/slurm-buildkite/climatimesteppers-ci/363/depot/cpu/packages/MPI/5cAQG/src/MPI.jl:90
```

I think this PR should fix it.