### PR TITLE
Add theoretic convergence order func stub

### DIFF
--- a/src/ClimaTimeSteppers.jl
+++ b/src/ClimaTimeSteppers.jl
@@ -64,8 +64,16 @@ include("functions.jl")
 include("operators.jl")
 include("algorithms.jl")
 
-abstract type DistributedODEAlgorithm <: DiffEqBase.AbstractODEAlgorithm
-end
+abstract type DistributedODEAlgorithm <: DiffEqBase.AbstractODEAlgorithm end
+
+"""
+    theoretical_convergence_order
+
+Returns the theoretical convergence order of an ODE algorithm
+"""
+function theoretical_convergence_order end
+theoretical_convergence_order(alg::DistributedODEAlgorithm) =
+    error("No convergence order found for algo $alg, please open an issue or PR.")
 
 SciMLBase.allowscomplex(alg::DistributedODEAlgorithm) = true
 include("integrators.jl")
@@ -88,5 +96,7 @@ include("solvers/wickerskamarock.jl")
 include("solvers/rosenbrock.jl")
 
 include("callbacks.jl")
+
+include("convergence_orders.jl")
 
 end

--- a/src/convergence_orders.jl
+++ b/src/convergence_orders.jl
@@ -1,0 +1,52 @@
+#####
+##### 1st order
+#####
+
+const first_order_methods = [
+    # ARS111,
+    # ARS121,
+]
+
+#####
+##### 2nd order
+#####
+
+const second_order_methods = [
+    # ARS122,
+    # ARS232,
+    # ARS222,
+    # IMKG232a,
+    # IMKG232b,
+    # IMKG242a,
+    # IMKG242b,
+    # IMKG252a,
+    # IMKG252b,
+    # IMKG253a,
+    # IMKG253b,
+    # IMKG254a,
+    # IMKG254b,
+    # IMKG254c,
+    # HOMMEM1,
+]
+
+#####
+##### 3rd order
+#####
+const third_order_methods = [
+    # ARS233,
+    # ARS343,
+    # ARS443,
+    # IMKG342a,
+    # IMKG343a,
+    # DBM453,
+]
+
+for m in first_order_methods
+    @eval theoretical_convergence_order(::$m) = 1
+end
+for m in second_order_methods
+    @eval theoretical_convergence_order(::$m) = 2
+end
+for m in third_order_methods
+    @eval theoretical_convergence_order(::$m) = 3
+end

--- a/src/solvers/imex_ark.jl
+++ b/src/solvers/imex_ark.jl
@@ -178,7 +178,7 @@ js_to_save(i, a) = filter(
 
 # Helper functions for tendencies
 has_implicit_step(i, a) = i <= size(a, 2) && a[i, i] != 0
-save_tendency(i, a) = 
+save_tendency(i, a) =
     !isnothing(findlast(i′ -> a[i′, i] != 0, (i + 1):size(a, 1)))
 
 # Helper functions for increments and tendencies
@@ -440,10 +440,10 @@ function not_generated_cache(
     ))
     newtons_method_cache =
         allocate_cache(alg.newtons_method, u, prob.f.f1.jac_prototype)
-    
+
     f_types = (typeof(prob.f.f2), typeof(prob.f.f1))
     @inbounds _cache = (;
-        _cache..., 
+        _cache...,
         u_alias_is_ = u_alias_is(as[1], as[2]),
         first_i_s = map(χ -> map(j -> first_i(j, as[χ]), j_range(as[χ])), Tuple(1:2)),
         new_js_s = map(χ -> map(i -> new_js(i, as[χ]), i_range(as[χ])), Tuple(1:2)),

--- a/test/ode_tests_common.jl
+++ b/test/ode_tests_common.jl
@@ -50,5 +50,5 @@ DirectSolver(args...) = DirectSolver()
 function (::DirectSolver)(x,A,b,matrix_updated; kwargs...)
     n = length(x)
     M = mapslices(y -> mul!(similar(y), A, y), Matrix{eltype(x)}(I,n,n), dims=1)
-    x .= M \ b 
+    x .= M \ b
 end


### PR DESCRIPTION
This PR adds a theoretic convergence order stub, that we can use per algorithm. This will be nice for users, and for our tests.