### PR TITLE
Make user-facing types

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ClimaTimeSteppers"
 uuid = "595c0a79-7f3d-439a-bc5a-b232dc3bde79"
 authors = ["Climate Modeling Alliance"]
-version = "0.2.6"
+version = "0.3.0"
 
 [deps]
 CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"

--- a/docs/src/algorithms.md
+++ b/docs/src/algorithms.md
@@ -16,7 +16,7 @@ ForwardEulerODEFunction
 
 ```@docs
 IMEXARKAlgorithm
-make_IMEXARKAlgorithm
+make_IMEXARKTableau
 ```
 
 The convergence orders of the provided methods are verified using test cases from [ARKode](http://runge.math.smu.edu/ARKode_example.pdf). Plots of the solutions to these test cases, the errors of these solutions, and the convergence orders with respect to `dt` are shown below.

--- a/perf/flame.jl
+++ b/perf/flame.jl
@@ -30,7 +30,7 @@ elseif problem_str=="fe"
 else
     error("Bad option")
 end
-algorithm = ARS343(NewtonsMethod(; max_iters = 2))
+algorithm = CTS.IMEXARKAlgorithm(ARS343(), NewtonsMethod(; max_iters = 2))
 dt = 0.01
 integrator = DiffEqBase.init(prob, algorithm; dt)
 not_generated_cache = CTS.not_generated_cache(prob, algorithm)

--- a/perf/jet.jl
+++ b/perf/jet.jl
@@ -15,7 +15,7 @@ end
 cts = joinpath(dirname(@__DIR__));
 include(joinpath(cts, "test", "problems.jl"))
 function config_integrators(problem)
-    algorithm = ARS343(NewtonsMethod(; linsolve = linsolve_direct, max_iters = 2))
+    algorithm = CTS.IMEXARKAlgorithm(ARS343(), NewtonsMethod(; linsolve = linsolve_direct, max_iters = 2))
     dt = 0.01
     integrator = DiffEqBase.init(problem, algorithm; dt)
     not_generated_integrator = DiffEqBase.init(problem, algorithm; dt)

--- a/src/ClimaTimeSteppers.jl
+++ b/src/ClimaTimeSteppers.jl
@@ -66,14 +66,24 @@ include("algorithms.jl")
 
 abstract type DistributedODEAlgorithm <: DiffEqBase.AbstractODEAlgorithm end
 
+abstract type AbstractIMEXARKAlgorithm <: DistributedODEAlgorithm end
+abstract type AbstractIMEXARKTableau end
+
+"""
+    tableau(::DistributedODEAlgorithm)
+
+Returns the tableau for a particular algorithm.
+"""
+function tableau end
+
 """
     theoretical_convergence_order
 
 Returns the theoretical convergence order of an ODE algorithm
 """
 function theoretical_convergence_order end
-theoretical_convergence_order(alg::DistributedODEAlgorithm) =
-    error("No convergence order found for algo $alg, please open an issue or PR.")
+theoretical_convergence_order(tab) =
+    error("No convergence order found for tableau $tab, please open an issue or PR.")
 
 SciMLBase.allowscomplex(alg::DistributedODEAlgorithm) = true
 include("integrators.jl")

--- a/src/convergence_orders.jl
+++ b/src/convergence_orders.jl
@@ -2,51 +2,53 @@
 ##### 1st order
 #####
 
-const first_order_methods = [
-    # ARS111,
-    # ARS121,
+# TODO: is it better to use `first_order_tableau = Union{ARS111,ARS121}`? to
+#       reduce the number of methods?
+const first_order_tableau = [
+    ARS111,
+    ARS121,
 ]
 
 #####
 ##### 2nd order
 #####
 
-const second_order_methods = [
-    # ARS122,
-    # ARS232,
-    # ARS222,
-    # IMKG232a,
-    # IMKG232b,
-    # IMKG242a,
-    # IMKG242b,
-    # IMKG252a,
-    # IMKG252b,
-    # IMKG253a,
-    # IMKG253b,
-    # IMKG254a,
-    # IMKG254b,
-    # IMKG254c,
-    # HOMMEM1,
+const second_order_tableau = [
+    ARS122,
+    ARS232,
+    ARS222,
+    IMKG232a,
+    IMKG232b,
+    IMKG242a,
+    IMKG242b,
+    IMKG252a,
+    IMKG252b,
+    IMKG253a,
+    IMKG253b,
+    IMKG254a,
+    IMKG254b,
+    IMKG254c,
+    HOMMEM1,
 ]
 
 #####
 ##### 3rd order
 #####
-const third_order_methods = [
-    # ARS233,
-    # ARS343,
-    # ARS443,
-    # IMKG342a,
-    # IMKG343a,
-    # DBM453,
+const third_order_tableau = [
+    ARS233,
+    ARS343,
+    ARS443,
+    IMKG342a,
+    IMKG343a,
+    DBM453,
 ]
 
-for m in first_order_methods
+for m in first_order_tableau
     @eval theoretical_convergence_order(::$m) = 1
 end
-for m in second_order_methods
+for m in second_order_tableau
     @eval theoretical_convergence_order(::$m) = 2
 end
-for m in third_order_methods
+for m in third_order_tableau
     @eval theoretical_convergence_order(::$m) = 3
 end

--- a/src/integrators.jl
+++ b/src/integrators.jl
@@ -50,7 +50,7 @@ function tstops_and_saveat_heaps(t0, tf, tstops, saveat)
     tstops = DataStructures.BinaryHeap{FT, ordering}(tstops)
 
     if isnothing(saveat)
-        saveat = [t0, tf]        
+        saveat = [t0, tf]
     elseif saveat isa Number
         saveat > zero(saveat) || error("saveat value must be positive")
         saveat = tf > t0 ? saveat : -saveat
@@ -101,7 +101,7 @@ function DiffEqBase.__init(
     callback = DiffEqBase.CallbackSet(callback, saving_callback)
     isempty(callback.continuous_callbacks) ||
         error("Continuous callbacks are not supported")
-    
+
     integrator = DistributedODEIntegrator(
         alg,
         u0,

--- a/src/solvers/imex_ark_tableaus.jl
+++ b/src/solvers/imex_ark_tableaus.jl
@@ -1,3 +1,4 @@
+export AbstractIMEXARKTableau
 export ARS111, ARS121, ARS122, ARS233, ARS232, ARS222, ARS343, ARS443
 export IMKG232a, IMKG232b, IMKG242a, IMKG242b, IMKG252a, IMKG252b
 export IMKG253a, IMKG253b, IMKG254a, IMKG254b, IMKG254c, IMKG342a, IMKG343a
@@ -16,27 +17,38 @@ using StaticArrays: @SArray, SMatrix, sacollect
 # the number of explicit stages, and p is the order of accuracy
 
 # This algorithm is equivalent to OrdinaryDiffEq.IMEXEuler.
-const ARS111 = make_IMEXARKAlgorithm(;
-    a_exp = @SArray([0 0; 1 0]),
-    a_imp = @SArray([0 0; 0 1]),
-)
+struct ARS111 <: AbstractIMEXARKTableau end
 
-const ARS121 = make_IMEXARKAlgorithm(;
-    a_exp = @SArray([0 0; 1 0]),
-    b_exp = @SArray([0, 1]),
-    a_imp = @SArray([0 0; 0 1]),
-)
+function tableau(::ARS111)
+    make_IMEXARKTableau(;
+        a_exp = @SArray([0 0; 1 0]),
+        a_imp = @SArray([0 0; 0 1]),
+    )
+end
 
-const ARS122 = make_IMEXARKAlgorithm(;
-    a_exp = @SArray([0 0; 1/2 0]),
-    b_exp = @SArray([0, 1]),
-    a_imp = @SArray([0 0; 0 1/2]),
-    b_imp = @SArray([0, 1]),
-)
+struct ARS121 <: AbstractIMEXARKTableau end
+function tableau(::ARS121)
+    make_IMEXARKTableau(;
+        a_exp = @SArray([0 0; 1 0]),
+        b_exp = @SArray([0, 1]),
+        a_imp = @SArray([0 0; 0 1]),
+    )
+end
 
-const ARS233 = let
+struct ARS122 <: AbstractIMEXARKTableau end
+function tableau(::ARS122)
+    make_IMEXARKTableau(;
+        a_exp = @SArray([0 0; 1/2 0]),
+        b_exp = @SArray([0, 1]),
+        a_imp = @SArray([0 0; 0 1/2]),
+        b_imp = @SArray([0, 1]),
+    )
+end
+
+struct ARS233 <: AbstractIMEXARKTableau end
+function tableau(::ARS233)
     γ = 1/2 + √3/6
-    make_IMEXARKAlgorithm(;
+    make_IMEXARKTableau(;
         a_exp = @SArray([
             0     0      0;
             γ     0      0;
@@ -52,10 +64,11 @@ const ARS233 = let
     )
 end
 
-const ARS232 = let
+struct ARS232 <: AbstractIMEXARKTableau end
+function tableau(::ARS232)
     γ = 1 - √2/2
     δ = -2√2/3
-    make_IMEXARKAlgorithm(;
+    make_IMEXARKTableau(;
         a_exp = @SArray([
             0 0     0;
             γ 0     0;
@@ -70,10 +83,11 @@ const ARS232 = let
     )
 end
 
-const ARS222 = let
+struct ARS222 <: AbstractIMEXARKTableau end
+function tableau(::ARS222)
     γ = 1 - √2/2
     δ = 1 - 1/2γ
-    make_IMEXARKAlgorithm(;
+    make_IMEXARKTableau(;
         a_exp = @SArray([
             0 0     0;
             γ 0     0;
@@ -87,7 +101,8 @@ const ARS222 = let
     )
 end
 
-const ARS343 = let
+struct ARS343 <: AbstractIMEXARKTableau end
+function tableau(::ARS343)
     γ = 0.4358665215084590
     a42 = 0.5529291480359398
     a43 = 0.5529291480359398
@@ -98,7 +113,7 @@ const ARS343 = let
     a32 = (-1 + 9/2 * γ - 3/2 * γ^2) * a42 +
         (-11/4 + 21/2 * γ - 15/4 * γ^2) * a43 + 4 - 25/2 * γ + 9/2 * γ^2
     a41 = 1 - a42 - a43
-    make_IMEXARKAlgorithm(;
+    make_IMEXARKTableau(;
         a_exp = @SArray([
             0   0   0   0;
             γ   0   0   0;
@@ -115,22 +130,25 @@ const ARS343 = let
     )
 end
 
-const ARS443 = make_IMEXARKAlgorithm(;
-    a_exp = @SArray([
-        0     0    0   0    0;
-        1/2   0    0   0    0;
-        11/18 1/18 0   0    0;
-        5/6   -5/6 1/2 0    0;
-        1/4   7/4  3/4 -7/4 0;
-    ]),
-    a_imp = @SArray([
-        0 0    0    0   0;
-        0 1/2  0    0   0;
-        0 1/6  1/2  0   0;
-        0 -1/2 1/2  1/2 0;
-        0 3/2  -3/2 1/2 1/2;
-    ]),
-)
+struct ARS443 <: AbstractIMEXARKTableau end
+function tableau(::ARS443)
+    make_IMEXARKTableau(;
+        a_exp = @SArray([
+            0     0    0   0    0;
+            1/2   0    0   0    0;
+            11/18 1/18 0   0    0;
+            5/6   -5/6 1/2 0    0;
+            1/4   7/4  3/4 -7/4 0;
+        ]),
+        a_imp = @SArray([
+            0 0    0    0   0;
+            0 1/2  0    0   0;
+            0 1/6  1/2  0   0;
+            0 -1/2 1/2  1/2 0;
+            0 3/2  -3/2 1/2 1/2;
+        ]),
+    )
+end
 
 ################################################################################
 
@@ -163,86 +181,122 @@ imkg_imp(i, j, α̂, β, δ̂) = i == j + 1 ? α̂[j] :
 function make_IMKGAlgorithm(α, α̂, δ̂, β = ntuple(_ -> 0, length(δ̂)))
     s = length(α̂) + 1
     type = SMatrix{s, s}
-    return make_IMEXARKAlgorithm(;
+    return make_IMEXARKTableau(;
         a_exp = sacollect(type, imkg_exp(i, j, α, β) for i in 1:s, j in 1:s),
         a_imp = sacollect(type, imkg_imp(i, j, α̂, β, δ̂) for i in 1:s, j in 1:s),
     )
 end
 
-const IMKG232a = make_IMKGAlgorithm(
-    (1/2, 1/2, 1),
-    (0, -1/2 + √2/2, 1),
-    (1 - √2/2, 1 - √2/2),
-)
+struct IMKG232a <: AbstractIMEXARKTableau end
+function tableau(::IMKG232a)
+    make_IMKGAlgorithm(
+        (1/2, 1/2, 1),
+        (0, -1/2 + √2/2, 1),
+        (1 - √2/2, 1 - √2/2),
+    )
+end
 
-const IMKG232b = make_IMKGAlgorithm(
-    (1/2, 1/2, 1),
-    (0, -1/2 - √2/2, 1),
-    (1 + √2/2, 1 + √2/2),
-)
+struct IMKG232b <: AbstractIMEXARKTableau end
+function tableau(::IMKG232b)
+    make_IMKGAlgorithm(
+        (1/2, 1/2, 1),
+        (0, -1/2 - √2/2, 1),
+        (1 + √2/2, 1 + √2/2),
+    )
+end
 
-const IMKG242a = make_IMKGAlgorithm(
-    (1/4, 1/3, 1/2, 1),
-    (0, 0, -1/2 + √2/2, 1),
-    (0, 1 - √2/2, 1 - √2/2),
-)
+struct IMKG242a <: AbstractIMEXARKTableau end
+function tableau(::IMKG242a)
+    make_IMKGAlgorithm(
+        (1/4, 1/3, 1/2, 1),
+        (0, 0, -1/2 + √2/2, 1),
+        (0, 1 - √2/2, 1 - √2/2),
+    )
+end
 
-const IMKG242b = make_IMKGAlgorithm(
-    (1/4, 1/3, 1/2, 1),
-    (0, 0, -1/2 - √2/2, 1),
-    (0, 1 + √2/2, 1 + √2/2),
-)
+struct IMKG242b <: AbstractIMEXARKTableau end
+function tableau(::IMKG242b)
+    make_IMKGAlgorithm(
+        (1/4, 1/3, 1/2, 1),
+        (0, 0, -1/2 - √2/2, 1),
+        (0, 1 + √2/2, 1 + √2/2),
+    )
+end
 
 # The paper uses √3/6 for α̂[3], which also seems to work.
-const IMKG243a = make_IMKGAlgorithm(
-    (1/4, 1/3, 1/2, 1),
-    (0, 1/6, -√3/6, 1),
-    (1/2 + √3/6, 1/2 + √3/6, 1/2 + √3/6),
-)
+struct IMKG243a <: AbstractIMEXARKTableau end
+function tableau(::IMKG243a)
+    make_IMKGAlgorithm(
+        (1/4, 1/3, 1/2, 1),
+        (0, 1/6, -√3/6, 1),
+        (1/2 + √3/6, 1/2 + √3/6, 1/2 + √3/6),
+    )
+end
 
-const IMKG252a = make_IMKGAlgorithm(
-    (1/4, 1/6, 3/8, 1/2, 1),
-    (0, 0, 0, -1/2 + √2/2, 1),
-    (0, 0, 1 - √2/2, 1 - √2/2),
-)
+struct IMKG252a <: AbstractIMEXARKTableau end
+function tableau(::IMKG252a)
+    make_IMKGAlgorithm(
+        (1/4, 1/6, 3/8, 1/2, 1),
+        (0, 0, 0, -1/2 + √2/2, 1),
+        (0, 0, 1 - √2/2, 1 - √2/2),
+    )
+end
 
-const IMKG252b = make_IMKGAlgorithm(
-    (1/4, 1/6, 3/8, 1/2, 1),
-    (0, 0, 0, -1/2 - √2/2, 1),
-    (0, 0, 1 + √2/2, 1 + √2/2),
-)
+struct IMKG252b <: AbstractIMEXARKTableau end
+function tableau(::IMKG252b)
+    make_IMKGAlgorithm(
+        (1/4, 1/6, 3/8, 1/2, 1),
+        (0, 0, 0, -1/2 - √2/2, 1),
+        (0, 0, 1 + √2/2, 1 + √2/2),
+    )
+end
 
 # The paper uses 0.08931639747704086 for α̂[3], which also seems to work.
-const IMKG253a = make_IMKGAlgorithm(
-    (1/4, 1/6, 3/8, 1/2, 1),
-    (0, 0, √3/4 * (1 - √3/3) * ((1 + √3/3)^2 - 2), √3/6, 1),
-    (0, 1/2 - √3/6, 1/2 - √3/6, 1/2 - √3/6),
-)
+struct IMKG253a <: AbstractIMEXARKTableau end
+function tableau(::IMKG253a)
+    make_IMKGAlgorithm(
+        (1/4, 1/6, 3/8, 1/2, 1),
+        (0, 0, √3/4 * (1 - √3/3) * ((1 + √3/3)^2 - 2), √3/6, 1),
+        (0, 1/2 - √3/6, 1/2 - √3/6, 1/2 - √3/6),
+    )
+end
 
 # The paper uses 1.2440169358562922 for α̂[3], which also seems to work.
-const IMKG253b = make_IMKGAlgorithm(
-    (1/4, 1/6, 3/8, 1/2, 1),
-    (0, 0, √3/4 * (1 + √3/3) * ((1 - √3/3)^2 - 2), -√3/6, 1),
-    (0, 1/2 + √3/6, 1/2 + √3/6, 1/2 + √3/6),
-)
+struct IMKG253b <: AbstractIMEXARKTableau end
+function tableau(::IMKG253b)
+    make_IMKGAlgorithm(
+        (1/4, 1/6, 3/8, 1/2, 1),
+        (0, 0, √3/4 * (1 + √3/3) * ((1 - √3/3)^2 - 2), -√3/6, 1),
+        (0, 1/2 + √3/6, 1/2 + √3/6, 1/2 + √3/6),
+    )
+end
 
-const IMKG254a = make_IMKGAlgorithm(
-    (1/4, 1/6, 3/8, 1/2, 1),
-    (0, -3/10, 5/6, -3/2, 1),
-    (-1/2, 1, 1, 2),
-)
+struct IMKG254a <: AbstractIMEXARKTableau end
+function tableau(::IMKG254a)
+    make_IMKGAlgorithm(
+        (1/4, 1/6, 3/8, 1/2, 1),
+        (0, -3/10, 5/6, -3/2, 1),
+        (-1/2, 1, 1, 2),
+    )
+end
 
-const IMKG254b = make_IMKGAlgorithm(
-    (1/4, 1/6, 3/8, 1/2, 1),
-    (0, -1/20, 5/4, -1/2, 1),
-    (-1/2, 1, 1, 1),
-)
+struct IMKG254b <: AbstractIMEXARKTableau end
+function tableau(::IMKG254b)
+    make_IMKGAlgorithm(
+        (1/4, 1/6, 3/8, 1/2, 1),
+        (0, -1/20, 5/4, -1/2, 1),
+        (-1/2, 1, 1, 1),
+    )
+end
 
-const IMKG254c = make_IMKGAlgorithm(
-    (1/4, 1/6, 3/8, 1/2, 1),
-    (0, 1/20, 5/36, 1/3, 1),
-    (1/6, 1/6, 1/6, 1/6),
-)
+struct IMKG254c <: AbstractIMEXARKTableau end
+function tableau(::IMKG254c)
+    make_IMKGAlgorithm(
+        (1/4, 1/6, 3/8, 1/2, 1),
+        (0, 1/20, 5/36, 1/3, 1),
+        (1/6, 1/6, 1/6, 1/6),
+    )
+end
 
 # The paper and HOMME completely disagree on this algorithm. Since the version
 # in the paper is not "342" (it appears to be "332"), the version from HOMME is
@@ -253,45 +307,60 @@ const IMKG254c = make_IMKGAlgorithm(
 #     (0, 1/2 + √3/6, 1/2 + √3/6),
 #     (1/3, 1/3, 1/4),
 # )
-const IMKG342a = make_IMKGAlgorithm(
-    (1/4, 2/3, 1/3, 3/4),
-    (0, 1/6 - √3/6, -1/6 - √3/6, 3/4),
-    (0, 1/2 + √3/6, 1/2 + √3/6),
-    (0, 1/3, 1/4),
-)
+struct IMKG342a <: AbstractIMEXARKTableau end
+function tableau(::IMKG342a)
+    make_IMKGAlgorithm(
+        (1/4, 2/3, 1/3, 3/4),
+        (0, 1/6 - √3/6, -1/6 - √3/6, 3/4),
+        (0, 1/2 + √3/6, 1/2 + √3/6),
+        (0, 1/3, 1/4),
+    )
+end
 
-const IMKG343a = make_IMKGAlgorithm(
-    (1/4, 2/3, 1/3, 3/4),
-    (0, -1/3, -2/3, 3/4),
-    (-1/3, 1, 1),
-    (0, 1/3, 1/4),
-)
+struct IMKG343a <: AbstractIMEXARKTableau end
+function tableau(::IMKG343a)
+    make_IMKGAlgorithm(
+        (1/4, 2/3, 1/3, 3/4),
+        (0, -1/3, -2/3, 3/4),
+        (-1/3, 1, 1),
+        (0, 1/3, 1/4),
+    )
+end
 
 # The paper and HOMME completely disagree on this algorithm, but neither version
 # is "353" (they appear to be "343" and "354", respectively).
-# const IMKG353a = make_IMKGAlgorithm(
-#     (1/4, 2/3, 1/3, 3/4),
-#     (0, -359/600, -559/600, 3/4),
-#     (-1.1678009811335388, 253/200, 253/200),
-#     (0, 1/3, 1/4),
-# )
-# const IMKG353a = make_IMKGAlgorithm(
-#     (-0.017391304347826087, -23/25, 5/3, 1/3, 3/4),
-#     (0.3075640504095504, -1.2990164859879263, 751/600, -49/60, 3/4),
-#     (-0.2981612530370581, 83/200, 83/200, 23/20),
-#     (1, -1, 1/3, 1/4),
-# )
+# struct IMKG353a <: AbstractIMEXARKTableau end
+# function tableau(::IMKG353a)
+#     make_IMKGAlgorithm(
+#         (1/4, 2/3, 1/3, 3/4),
+#         (0, -359/600, -559/600, 3/4),
+#         (-1.1678009811335388, 253/200, 253/200),
+#         (0, 1/3, 1/4),
+#     )
+# end
+# struct IMKG353a <: AbstractIMEXARKTableau end
+# function tableau(::IMKG353a)
+#     make_IMKGAlgorithm(
+#         (-0.017391304347826087, -23/25, 5/3, 1/3, 3/4),
+#         (0.3075640504095504, -1.2990164859879263, 751/600, -49/60, 3/4),
+#         (-0.2981612530370581, 83/200, 83/200, 23/20),
+#         (1, -1, 1/3, 1/4),
+#     )
+# end
 
 # The version of this algorithm in the paper is not "354" (it appears to be
 # "253"), and this algorithm is missing from HOMME (or, more precisely, the
 # tableau for IMKG353a is mistakenly used to define IMKG354a, and the tableau
 # for IMKG354a is not specified).
-# const IMKG354a = make_IMKGAlgorithm(
-#     (1/5, 1/5, 2/3, 1/3, 3/4),
-#     (0, 0, 11/30, -2/3, 3/4),
-#     (0, 2/4, 2/5, 1),
-#     (0, 0, 1/3, 1/4),
-# )
+# struct IMKG354a <: AbstractIMEXARKTableau end
+# function tableau(::IMKG354a)
+#     make_IMKGAlgorithm(
+#         (1/5, 1/5, 2/3, 1/3, 3/4),
+#         (0, 0, 11/30, -2/3, 3/4),
+#         (0, 2/4, 2/5, 1),
+#         (0, 0, 1/3, 1/4),
+#     )
+# end
 
 ################################################################################
 
@@ -302,9 +371,10 @@ const IMKG343a = make_IMKGAlgorithm(
 
 # The algorithm has 4 implicit stages, 5 overall stages, and 3rd order accuracy.
 
-const DBM453 = let
+struct DBM453 <: AbstractIMEXARKTableau end
+function tableau(::DBM453)
     γ = 0.32591194130117247
-    make_IMEXARKAlgorithm(;
+    make_IMEXARKTableau(;
         a_exp = @SArray([
             0                    0                   0                   0                    0;
             0.10306208811591838  0                   0                   0                    0;
@@ -334,21 +404,24 @@ end
 
 # The algorithm has 5 implicit stages, 6 overall stages, and 2rd order accuracy.
 
-const HOMMEM1 = make_IMEXARKAlgorithm(;
-    a_exp = @SArray([
-        0   0   0   0   0   0;
-        1/5 0   0   0   0   0;
-        0   1/5 0   0   0   0;
-        0   0   1/3 0   0   0;
-        0   0   0   1/2 0   0;
-        0   0   0   0   1   0;
-    ]),
-    a_imp = @SArray([
-        0    0    0    0    0    0;
-        0    1/5  0    0    0    0;
-        0    0    1/5  0    0    0;
-        0    0    0    1/3  0    0;
-        0    0    0    0    1/2  0;
-        5/18 5/18 0    0    0    8/18;
-    ]),
-)
+struct HOMMEM1 <: AbstractIMEXARKTableau end
+function tableau(::HOMMEM1)
+    make_IMEXARKTableau(;
+        a_exp = @SArray([
+            0   0   0   0   0   0;
+            1/5 0   0   0   0   0;
+            0   1/5 0   0   0   0;
+            0   0   1/3 0   0   0;
+            0   0   0   1/2 0   0;
+            0   0   0   0   1   0;
+        ]),
+        a_imp = @SArray([
+            0    0    0    0    0    0;
+            0    1/5  0    0    0    0;
+            0    0    1/5  0    0    0;
+            0    0    0    1/3  0    0;
+            0    0    0    0    1/2  0;
+            5/18 5/18 0    0    0    8/18;
+        ]),
+    )
+end

--- a/test/compare_generated.jl
+++ b/test/compare_generated.jl
@@ -1,9 +1,10 @@
+import ClimaTimeSteppers as CTS
 using Test, BenchmarkTools, DiffEqBase, ClimaTimeSteppers
 
 include("problems.jl")
 
 @testset "Generated vs. Not Generated" begin
-    algorithm = ARS343(NewtonsMethod(; max_iters = 2))
+    algorithm = CTS.IMEXARKAlgorithm(ARS343(), NewtonsMethod(; max_iters = 2))
     dt = 0.01
     for problem in (
         split_linear_prob_wfact_split(),

--- a/test/convergence.jl
+++ b/test/convergence.jl
@@ -46,20 +46,15 @@ end
 ENV["GKSwstype"] = "nul" # avoid displaying plots
 
 @testset "IMEX ARK Algorithms" begin
-    algs1 = (ARS111, ARS121)
-    algs2 = (ARS122, ARS232, ARS222, IMKG232a, IMKG232b, IMKG242a, IMKG242b)
-    algs2 = (algs2..., IMKG252a, IMKG252b, IMKG253a, IMKG253b, IMKG254a)
-    algs2 = (algs2..., IMKG254b, IMKG254c, HOMMEM1)
-    algs3 = (ARS233, ARS343, ARS443, IMKG342a, IMKG343a, DBM453)
-    dict = Dict(((algs1 .=> 1)..., (algs2 .=> 2)..., (algs3 .=> 3)...))
-    test_algs("IMEX ARK", dict, ark_analytic_nonlin_test(Float64), 400)
-    test_algs("IMEX ARK", dict, ark_analytic_sys_test(Float64), 60)
-
-    # For some bizarre reason, ARS121 converges with order 2 for ark_analytic,
-    # even though it is only a 1st order method.
-    dict′ = copy(dict)
-    dict′[ARS121] = 2
-    test_algs("IMEX ARK", dict′, ark_analytic_test(Float64), 16000)
+    tab1 = (ARS111, ARS121)
+    tab2 = (ARS122, ARS232, ARS222, IMKG232a, IMKG232b, IMKG242a, IMKG242b)
+    tab2 = (tab2..., IMKG252a, IMKG252b, IMKG253a, IMKG253b, IMKG254a)
+    tab2 = (tab2..., IMKG254b, IMKG254c, HOMMEM1)
+    tab3 = (ARS233, ARS343, ARS443, IMKG342a, IMKG343a, DBM453)
+    tabs = [tab1..., tab2..., tab3...]
+    test_algs("IMEX ARK", tabs, ark_analytic_nonlin_test(Float64), 400)
+    test_algs("IMEX ARK", tabs, ark_analytic_sys_test(Float64), 60)
+    test_algs("IMEX ARK", tabs, ark_analytic_test(Float64), 16000; super_convergence=ARS121)
 end
 
 #=

--- a/test/single_column_ARS_test.jl
+++ b/test/single_column_ARS_test.jl
@@ -1,4 +1,5 @@
 using DiffEqBase, ClimaTimeSteppers, LinearAlgebra, StaticArrays, Test
+import ClimaTimeSteppers as CTS
 # Unit test for ARS schemes on the single column hydrostatic problem
 # Here we run 1 time step and 1 Newton iteration to compare the result
 mutable struct Single_Stack
@@ -264,12 +265,12 @@ end
 
 
     algorithms = (
-        ARS111(NewtonsMethod(; max_iters = 1)),
-        ARS121(NewtonsMethod(; max_iters = 1)),
-        ARS122(NewtonsMethod(; max_iters = 1)),
-        ARS232(NewtonsMethod(; max_iters = 1)),
-        ARS222(NewtonsMethod(; max_iters = 1)),
-        ARS343(NewtonsMethod(; max_iters = 1)),
+        CTS.IMEXARKAlgorithm(ARS111(), NewtonsMethod(; max_iters = 1)),
+        CTS.IMEXARKAlgorithm(ARS121(), NewtonsMethod(; max_iters = 1)),
+        CTS.IMEXARKAlgorithm(ARS122(), NewtonsMethod(; max_iters = 1)),
+        CTS.IMEXARKAlgorithm(ARS232(), NewtonsMethod(; max_iters = 1)),
+        CTS.IMEXARKAlgorithm(ARS222(), NewtonsMethod(; max_iters = 1)),
+        CTS.IMEXARKAlgorithm(ARS343(), NewtonsMethod(; max_iters = 1)),
     )
     reference_sol_norm = [860.2745315698107; 860.2745315698107; 860.4393569534262;
                           860.452530117785; 860.452530117785; ref_ARS343]

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -1,10 +1,13 @@
 import Plots, Printf
+import ClimaTimeSteppers as CTS
 using Test
+
+has_increment_formulation(::CTS.AbstractIMEXARKTableau) = true
 
 """
     test_algs(
         algs_name,
-        algs_to_order,
+        algs,
         test_case,
         num_steps;
         save_every_n_steps = max(1, Int(fld(num_steps, 500))),
@@ -19,7 +22,7 @@ errors with respect to `dt`.
 
 # Arguments
 - `algs_name::String`: the name of the collection of algorithms
-- `algs_to_order::Dict`: a mapping from each algorithm to its convergence order
+- `tableaus`: an array of tableaus
 - `test_case::IntegratorTestCase`: the test case to use
 - `num_steps::Int`: the numerical solutions for the solution and error plots
       are computed with `dt = t_end / num_steps`, while the solutions for
@@ -29,17 +32,14 @@ errors with respect to `dt`.
       values at every `n`-th step; the default value is such that 500-999 steps
       are plotted (unless there are fewer than 500 steps, in which case every
       step is plotted)
-- `no_increment_algs::Tuple`: a collection of algorithms that do not have a
-      working increment formulation; the increment comparison test is skipped
-      for algorithms in this collection
 """
 function test_algs(
     algs_name,
-    algs_to_order,
+    tableaus,
     test_case,
     num_steps;
     save_every_n_steps = Int(cld(num_steps, 500)),
-    no_increment_algs = (),
+    super_convergence = nothing
 )
     (; test_name, linear_implicit, t_end, analytic_sol) = test_case
     FT = typeof(t_end)
@@ -87,19 +87,24 @@ function test_algs(
     analytic_sols = map(analytic_sol, plot1_saveat)
     analytic_end_sol = [analytic_sols[end]]
 
-    sorted_algs_to_order = sort(collect(algs_to_order); by = x -> string(x[1]))
-    for (alg_name, predicted_order) in sorted_algs_to_order
-        if alg_name <: IMEXARKAlgorithm
+    for tab in tableaus
+        if tab() isa AbstractIMEXARKTableau
             max_iters = linear_implicit ? 1 : 2 # TODO: is 2 enough?
-            alg = alg_name(NewtonsMethod(; max_iters))
+            alg = CTS.IMEXARKAlgorithm(tab(), NewtonsMethod(; max_iters))
             tendency_prob = test_case.split_prob
             increment_prob = test_case.split_increment_prob
         else
-            alg = alg_name()
+            alg = tab()
             tendency_prob = test_case.prob
             increment_prob = test_case.increment_prob
         end
+        predicted_order = if super_convergence==tab
+            CTS.theoretical_convergence_order(tab())+1
+        else
+            CTS.theoretical_convergence_order(tab())
+        end
         linestyle = linestyles[(predicted_order - 1) % length(linestyles) + 1]
+        alg_name = string(nameof(tab))
 
         # Use tstops to fix saving issues due to machine precision (e.g. if the
         # integrator needs to save at t but it stops at t - eps(), it will skip
@@ -117,12 +122,12 @@ function test_algs(
         Plots.plot!(plot1a, plot1_saveat, tendency_norms; label = alg_name, linestyle)
         Plots.plot!(plot1b, plot1_saveat, tendency_errs; label = alg_name, linestyle)
 
-        if !(alg_name in no_increment_algs)
+        if has_increment_formulation(tab())
             increment_sols =
                 solve(deepcopy(increment_prob), alg; solve_args...).u
             increment_errs = @. norm(increment_sols - tendency_sols)
             @test maximum(increment_errs) < 1000 * eps(FT) broken =
-                alg_name == HOMMEM1 # TODO: why is this one broken?
+                alg_name == "HOMMEM1" # TODO: why is this one broken?
         end
 
         tendency_end_sols =


### PR DESCRIPTION
This PR:
 - Adds a new abstract type `AbstractImexARKAlgorithm <: DistributedODEAlgorithm`
 - Adds user-facing types for all of the imex ark algorithms, all of which subtype `AbstractImexARKAlgorithm`
 - Defines `theoretical_convergence_order` for these new types
 - Adjusts the tests accordingly

This should all help with two things
 - Initializing algorithms. One issue we've had in ClimaAtmos is that initializing an algorithm requires first inspecting if an algorithm is a function, in which case assumptions are made about how that function is called. This is really clunky, and usage requires understanding ClimaTimeStepper internals.
 - Documentation. Several of these existing "algorithms", are just constants pointing to a generic tableau specific to that algorithm. Documenting these algorithms is part of our requirements, so this must be redesigned.

This should help us more easily peel off parts from the ClimaAtmos PR, and the revamp PR.