### PR TITLE
Clean up update_j and KrylovMethod

### DIFF
--- a/docs/src/newtons_method.md
+++ b/docs/src/newtons_method.md
@@ -44,8 +44,9 @@ MultipleConditions
 UpdateSignalHandler
 UpdateEvery
 UpdateEveryN
+UpdateEveryDt
 UpdateSignal
-NewStep
+NewTimeStep
 NewNewtonSolve
 NewNewtonIteration
 ```

--- a/src/solvers/update_signal_handler.jl
+++ b/src/solvers/update_signal_handler.jl
@@ -1,5 +1,5 @@
-export UpdateSignal, NewStep, NewNewtonSolve, NewNewtonIteration
-export UpdateSignalHandler, UpdateEvery, UpdateEveryN
+export UpdateSignal, NewTimeStep, NewNewtonSolve, NewNewtonIteration
+export UpdateSignalHandler, UpdateEvery, UpdateEveryN, UpdateEveryDt
 
 """
     UpdateSignal
@@ -10,11 +10,13 @@ operation is performed.
 abstract type UpdateSignal end
 
 """
-    NewStep()
+    NewTimeStep(t)
 
-The signal for a new time step.
+The signal for a new time step at time `t`.
 """
-struct NewStep <: UpdateSignal end
+struct NewTimeStep{T} <: UpdateSignal
+    t::T
+end
 
 """
     NewNewtonSolve()
@@ -37,62 +39,78 @@ struct NewNewtonIteration <: UpdateSignal end
 Updates a value upon receiving an appropriate `UpdateSignal`. This is done by
 calling `run!(::UpdateSignalHandler, cache, ::UpdateSignal, f!, args...)`, where
 `f!` is function such that `f!(args...)` modifies the desired value in-place.
-The `cache` can be obtained with `allocate_cache(::UpdateSignalHandler)`.
+The `cache` can be obtained with `allocate_cache(::UpdateSignalHandler, FT)`,
+where `FT` is the floating-point type of the integrator.
 """
 abstract type UpdateSignalHandler end
 
 """
-    UpdateEvery(update_signal)
+    UpdateEvery(update_signal_type)
 
-An `UpdateSignalHandler` that executes the update every time it is `run!` with
-`update_signal`.
+An `UpdateSignalHandler` that performs the update whenever it is `run!` with an
+`UpdateSignal` of type `update_signal_type`.
 """
-struct UpdateEvery{U <: UpdateSignal} <: UpdateSignalHandler
-    update_signal::U
-end
+struct UpdateEvery{U <: UpdateSignal} <: UpdateSignalHandler end
+UpdateEvery(::Type{U}) where {U} = UpdateEvery{U}()
 
-allocate_cache(::UpdateSignalHandler) = (;)
-
-function run!(alg::UpdateEvery{U}, cache, ::U, f!, args...) where {
-    U <: UpdateSignal,
-}
-    f!(args...)
-    return true
-end
+run!(alg::UpdateEvery{U}, cache, ::U, f!, args...) where {U} = f!(args...)
 
 """
-    UpdateEveryN(update_signal, n, reset_n_signal = nothing)
+    UpdateEveryN(n, update_signal_type, reset_signal_type = Nothing)
 
-An `UpdateSignalHandler` that executes the update every `n`-th time it is `run!`
-with `update_signal`. If `reset_n_signal` is specified, then the value of `n` is
-reset to 0 every time the signal handler is `run!` with `reset_n_signal`.
+An `UpdateSignalHandler` that performs the update every `n`-th time it is `run!`
+with an `UpdateSignal` of type `update_signal_type`. If `reset_signal_type` is
+specified, then the counter (which gets incremented from 0 to `n` and then gets
+reset to 0 when it is time to perform another update) is reset to 0 whenever the
+signal handler is `run!` with an `UpdateSignal` of type `reset_signal_type`.
 """
 struct UpdateEveryN{U <: UpdateSignal, R <: Union{Nothing, UpdateSignal}} <:
     UpdateSignalHandler
-    update_signal::U
     n::Int
-    reset_n_signal::R
 end
-UpdateEveryN(update_signal, n, reset_n_signal = nothing) =
-    UpdateEveryN(update_signal, n, reset_n_signal)
+UpdateEveryN(n, ::Type{U}, ::Type{R} = Nothing) where {U, R} =
+    UpdateEveryN{U, R}(n)
 
-allocate_cache(::UpdateEveryN) = (; n = Ref(0))
+allocate_cache(::UpdateEveryN, _) = (; counter = Ref(0))
 
-function run!(alg::UpdateEveryN{U}, cache, ::U, f!, args...) where {
-    U <: UpdateSignal,
-}
-    cache.n[] += 1
-    if cache.n[] == alg.n
+function run!(alg::UpdateEveryN{U}, cache, ::U, f!, args...) where {U}
+    (; n) = alg
+    (; counter) = cache
+    if counter[] == 0
         f!(args...)
-        cache.n[] = 0
-        return true
     end
-    return false
+    counter[] += 1
+    if counter[] == n
+        counter[] = 0
+    end
 end
-function run!(alg::UpdateEveryN{U, R}, cache, ::R, f!, args...) where {
-    U,
-    R <: UpdateSignal,
-}
-    cache.n[] = 0
-    return false
+function run!(alg::UpdateEveryN{<:Any, R}, cache, ::R, f!, args...) where {R}
+    (; counter) = cache
+    counter[] = 0
+end
+
+"""
+    UpdateEveryDt(dt)
+
+An `UpdateSignalHandler` that performs the update whenever it is `run!` with an
+`UpdateSignal` of type `NewTimeStep` and the difference between the current time
+and the previous update time is no less than `dt`.
+"""
+struct UpdateEveryDt{T} <: UpdateSignalHandler
+    dt::T
+end
+
+# TODO: This assumes that typeof(t) == FT, which might not always be correct.
+allocate_cache(alg::UpdateEveryDt, ::Type{FT}) where {FT} =
+    (; is_first_t = Ref(true), prev_update_t = Ref{FT}())
+
+function run!(alg::UpdateEveryDt, cache, signal::NewTimeStep, f!, args...)
+    (; dt) = alg
+    (; is_first_t, prev_update_t) = cache
+    (; t) = signal
+    if is_first_t[] || abs(t - prev_update_t[]) >= dt
+        f!(args...)
+        is_first_t[] = false
+        prev_update_t[] = t
+    end
 end


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
<!--- One sentence to describe the purpose of this PR, refer to any linked issues:
#14 -- this will link to issue 14
Closes #2 -- this will automatically close issue 2 on PR merge
-->
This PR improves the `update_j` interface, which allows for the Jacobian to be updated at arbitrary times (not just on every Newton iteration). It also slightly cleans up the `KrylovMethod` struct.

## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->
- Gives `NewtonsMethod` an `update!` function, which propagates an external `UpdateSignal` to the `update_j` signal handler in `NewtonsMethod`. This interface could potentially be extended to other values in the `NewtonsMethod` cache that we want to update while `NewtonsMethod` is not running. The new functionality is described in the documentation for `NewtonsMethod`.
- Replaces the value of `a_imp[end, end]` in `step_u!`'s manual Jacobian update with `γ`, which is either the unique non-zero value along the diagonal of `a_imp` or `nothing` if no such value exists. If the user specifies that the Jacobian should be updated every `n` timesteps, but they specify an algorithm whose tableau does not have a unique value of `γ`, they will encounter an informative error message before the Jacobian gets computed.
- Renames the `NewStep` signal to `NewTimeStep` and allows the signal to propagate the current integrator time `t`.
- Simplifies the `UpdateEvery` signal handler, simplifies and fixes a bug in the `UpdateEveryN` signal handler, and adds the `UpdateEveryDt` signal handler. The documentation is updated appropriately.
- Moves the assertion `@assert type isa Type{<:Krylov.KrylovSolver}` from `allocate_cache` to the definition of `KrylovMethod`, making it impossible to construct a `KrylovMethod` with an invalid solver type.
- Rewords the documentation of `KrylovMethod` to clarify why `type` should be wrapped in `Val`.

<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [x] I have read and checked the items on the review checklist.
