### PR TITLE
Use julia depot path in buildkite, disable gpu env

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -35,32 +35,32 @@ steps:
       queue: central
       slurm_ntasks: 1
 
-  - label: "init gpu env"
-    key: "init_gpu_env"
-    command:
-      - echo "--- Configure MPI"
-      - julia -e 'using Pkg; Pkg.add("MPIPreferences"); using MPIPreferences; use_system_binary()'
+  # - label: "init gpu env"
+  #   key: "init_gpu_env"
+  #   command:
+  #     - echo "--- Configure MPI"
+  #     - julia -e 'using Pkg; Pkg.add("MPIPreferences"); using MPIPreferences; use_system_binary()'
 
-      - echo "--- Instantiate project"
-      - "julia --project -e 'using Pkg; Pkg.instantiate(;verbose=true)'"
-      - "julia --project -e 'using Pkg; Pkg.precompile(;strict=true)'"
+  #     - echo "--- Instantiate project"
+  #     - "julia --project -e 'using Pkg; Pkg.instantiate(;verbose=true)'"
+  #     - "julia --project -e 'using Pkg; Pkg.precompile(;strict=true)'"
 
-      - echo "--- Instantiate test"
-      - "julia --project=test -e 'using Pkg; Pkg.develop(path=\".\")'"
-      - "julia --project=test -e 'using Pkg; Pkg.instantiate(;verbose=true)'"
-      - "julia --project=test -e 'using Pkg; Pkg.precompile()'"
+  #     - echo "--- Instantiate test"
+  #     - "julia --project=test -e 'using Pkg; Pkg.develop(path=\".\")'"
+  #     - "julia --project=test -e 'using Pkg; Pkg.instantiate(;verbose=true)'"
+  #     - "julia --project=test -e 'using Pkg; Pkg.precompile()'"
 
-      - echo "--- Initialize CUDA runtime"
-      - "julia --project -e 'using CUDA; CUDA.precompile_runtime()'"
-      - "julia --project -e 'using CUDA; CUDA.versioninfo()'"
+  #     - echo "--- Initialize CUDA runtime"
+  #     - "julia --project -e 'using CUDA; CUDA.precompile_runtime()'"
+  #     - "julia --project -e 'using CUDA; CUDA.versioninfo()'"
 
-      - echo "--- Package status"
-      - "julia --project -e 'using Pkg; Pkg.status()'"
-    agents:
-      config: gpu
-      queue: central
-      slurm_ntasks: 1
-      slurm_gres: "gpu:1"
+  #     - echo "--- Package status"
+  #     - "julia --project -e 'using Pkg; Pkg.status()'"
+  #   agents:
+  #     config: gpu
+  #     queue: central
+  #     slurm_ntasks: 1
+  #     slurm_gres: "gpu:1"
 
   - wait
 
@@ -73,15 +73,15 @@ steps:
       queue: central
       slurm_ntasks: 1
 
-  - label: "GPU tests"
-    command:
-      - "julia --project=test --check-bounds=yes test/runtests.jl CuArray"
-    artifact_paths: "output/*"
-    agents:
-      config: gpu
-      queue: central
-      slurm_ntasks: 1
-      slurm_gres: "gpu:1"
+  # - label: "GPU tests"
+  #   command:
+  #     - "julia --project=test --check-bounds=yes test/runtests.jl CuArray"
+  #   artifact_paths: "output/*"
+  #   agents:
+  #     config: gpu
+  #     queue: central
+  #     slurm_ntasks: 1
+  #     slurm_gres: "gpu:1"
 
   - label: "Flame graph (ode fun)"
     command:

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -4,11 +4,13 @@ env:
   OPENMPI_VERSION: "4.1.1"
   OPENBLAS_NUM_THREADS: 1
   CLIMATEMACHINE_SETTINGS_FIX_RNG_SEED: "true"
+  JULIA_DEPOT_PATH: "${BUILDKITE_BUILD_PATH}/${BUILDKITE_PIPELINE_SLUG}/depot/cpu"
 
 steps:
   - label: "init cpu env"
     key: "init_cpu_env"
     command:
+      - "echo $$JULIA_DEPOT_PATH"
       - echo "--- Configure MPI"
       - julia -e 'using Pkg; Pkg.add("MPIPreferences"); using MPIPreferences; use_system_binary()'
 


### PR DESCRIPTION
This PR adds the use of the Julia depot path, to speed up CI times.

I've also disabled the gpu env, since this seems to be needed to be built serially and it's not currently being used.