### PR TITLE
Add benchmark back into CI

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -100,3 +100,11 @@ steps:
       config: cpu
       queue: central
       slurm_ntasks: 1
+
+  - label: "Benchmark"
+    command:
+      - "julia --project=perf perf/benchmark.jl"
+    agents:
+      config: cpu
+      queue: central
+      slurm_ntasks: 1

--- a/perf/benchmark.jl
+++ b/perf/benchmark.jl
@@ -1,0 +1,21 @@
+import ClimaTimeSteppers as CTS
+import DiffEqBase
+using BenchmarkTools, DiffEqBase
+
+include(joinpath(pkgdir(CTS), "test", "problems.jl"))
+
+function main()
+    algorithm = CTS.IMEXARKAlgorithm(CTS.ARS343(), CTS.NewtonsMethod(; max_iters = 2))
+    dt = 0.01
+    for problem in (split_linear_prob_wfact_split(), split_linear_prob_wfact_split_fe())
+        integrator = DiffEqBase.init(problem, algorithm; dt)
+
+        cache = CTS.cache(problem, algorithm)
+
+        CTS.step_u!(integrator, cache)
+
+        trial = @benchmark CTS.step_u!($integrator, $cache)
+        show(stdout, MIME("text/plain"), trial)
+    end
+end
+main()


### PR DESCRIPTION
This PR adds the benchmark back into CI, removed in #105. This script just prints the results of `@benchmark` for a couple problems