### PR TITLE
Add and fix JET test

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -101,6 +101,22 @@ steps:
       queue: central
       slurm_ntasks: 1
 
+  - label: "Jet graph (ode fun)"
+    command:
+      - "julia --project=perf perf/jet.jl --problem ode_fun"
+    agents:
+      config: cpu
+      queue: central
+      slurm_ntasks: 1
+
+  - label: "Jet (forward euler)"
+    command:
+      - "julia --project=perf perf/jet.jl --problem fe"
+    agents:
+      config: cpu
+      queue: central
+      slurm_ntasks: 1
+
   - label: "Benchmark"
     command:
       - "julia --project=perf perf/benchmark.jl"


### PR DESCRIPTION
This PR adds a JET test and fixes the failures by making the `verbose` option a compile-time constant.