### PR TITLE
Rename cache method to init_cache

### DIFF
--- a/perf/benchmark.jl
+++ b/perf/benchmark.jl
@@ -10,7 +10,7 @@ function main()
     for problem in (split_linear_prob_wfact_split(), split_linear_prob_wfact_split_fe())
         integrator = DiffEqBase.init(problem, algorithm; dt)
 
-        cache = CTS.cache(problem, algorithm)
+        cache = CTS.init_cache(problem, algorithm)
 
         CTS.step_u!(integrator, cache)
 

--- a/perf/flame.jl
+++ b/perf/flame.jl
@@ -33,7 +33,7 @@ end
 algorithm = CTS.IMEXARKAlgorithm(ARS343(), NewtonsMethod(; max_iters = 2))
 dt = 0.01
 integrator = DiffEqBase.init(prob, algorithm; dt)
-cache = CTS.cache(prob, algorithm)
+cache = CTS.init_cache(prob, algorithm)
 do_work!(integrator, cache) # compile first
 import Profile
 Profile.clear_malloc_data()

--- a/perf/jet.jl
+++ b/perf/jet.jl
@@ -18,7 +18,7 @@ function config_integrators(problem)
     algorithm = CTS.IMEXARKAlgorithm(ARS343(), NewtonsMethod(; max_iters = 2))
     dt = 0.01
     integrator = DiffEqBase.init(problem, algorithm; dt)
-    integrator.cache = CTS.cache(problem, algorithm)
+    integrator.cache = CTS.init_cache(problem, algorithm)
     return (; integrator)
 end
 prob = if parsed_args["problem"] == "ode_fun"

--- a/src/integrators.jl
+++ b/src/integrators.jl
@@ -114,7 +114,7 @@ function DiffEqBase.__init(
         callback,
         advance_to_tstop,
         false,
-        cache(prob, alg; dt, kwargs...),
+        init_cache(prob, alg; dt, kwargs...),
         sol,
     )
     DiffEqBase.initialize!(callback, u0, t0, integrator)

--- a/src/solvers/ark.jl
+++ b/src/solvers/ark.jl
@@ -42,7 +42,7 @@ struct AdditiveRungeKuttaFullCache{Nstages, RT, A, O, L}
 end
 
 
-function cache(
+function init_cache(
     prob::DiffEqBase.AbstractODEProblem{uType, tType, true},
     alg::AdditiveRungeKutta;
     dt,

--- a/src/solvers/imex_ark.jl
+++ b/src/solvers/imex_ark.jl
@@ -49,7 +49,7 @@ struct IMEXARKCache{SCU, SCE, SCI, T, Γ, NMC}
     newtons_method_cache::NMC
 end
 
-function cache(prob::DiffEqBase.AbstractODEProblem, alg::IMEXARKAlgorithm; kwargs...)
+function init_cache(prob::DiffEqBase.AbstractODEProblem, alg::IMEXARKAlgorithm; kwargs...)
     (; u0, f) = prob
     (; T_imp!) = f
     (; tab, newtons_method) = alg

--- a/src/solvers/lsrk.jl
+++ b/src/solvers/lsrk.jl
@@ -33,7 +33,7 @@ struct LowStorageRungeKutta2NIncCache{Nstages, RT, A}
     du::A
 end
 
-function cache(prob::DiffEqBase.ODEProblem, alg::LowStorageRungeKutta2N; kwargs...)
+function init_cache(prob::DiffEqBase.ODEProblem, alg::LowStorageRungeKutta2N; kwargs...)
     # @assert prob.problem_type isa DiffEqBase.IncrementingODEProblem ||
     #     prob.f isa DiffEqBase.IncrementingODEFunction
     du = zero(prob.u0)

--- a/src/solvers/mis.jl
+++ b/src/solvers/mis.jl
@@ -51,7 +51,7 @@ end
 
 nstages(::MultirateInfinitesimalStepCache{Nstages}) where {Nstages} = Nstages
 
-function cache(
+function init_cache(
     prob::DiffEqBase.AbstractODEProblem{uType, tType, true},
     alg::MultirateInfinitesimalStep;
     kwargs...,

--- a/src/solvers/multirate.jl
+++ b/src/solvers/multirate.jl
@@ -24,13 +24,13 @@ struct MultirateCache{OC, II}
     innerinteg::II
 end
 
-function cache(prob::DiffEqBase.AbstractODEProblem, alg::Multirate; dt, fast_dt, kwargs...)
+function init_cache(prob::DiffEqBase.AbstractODEProblem, alg::Multirate; dt, fast_dt, kwargs...)
 
     @assert prob.f isa DiffEqBase.SplitFunction
 
     # subproblems
     outerprob = DiffEqBase.remake(prob; f = prob.f.f2)
-    outercache = cache(outerprob, alg.slow)
+    outercache = init_cache(outerprob, alg.slow)
 
     innerfun = init_inner(prob, outercache, dt)
     innerprob = DiffEqBase.remake(prob; f = innerfun)

--- a/src/solvers/rosenbrock.jl
+++ b/src/solvers/rosenbrock.jl
@@ -18,7 +18,7 @@ struct RosenbrockCache{Nstages, RT, N², A}
     linsolve!::Any
 end
 
-function cache(prob::DiffEqBase.AbstractODEProblem, alg::RosenbrockAlgorithm; kwargs...)
+function init_cache(prob::DiffEqBase.AbstractODEProblem, alg::RosenbrockAlgorithm; kwargs...)
 
     tab = tableau(alg, eltype(prob.u0))
     Nstages = length(tab.m)

--- a/src/solvers/ssprk.jl
+++ b/src/solvers/ssprk.jl
@@ -34,7 +34,7 @@ struct StrongStabilityPreservingRungeKuttaCache{Nstages, RT, A}
     U::A
 end
 
-function cache(prob::DiffEqBase.AbstractODEProblem, alg::StrongStabilityPreservingRungeKutta; kwargs...)
+function init_cache(prob::DiffEqBase.AbstractODEProblem, alg::StrongStabilityPreservingRungeKutta; kwargs...)
 
     tab = tableau(alg, eltype(prob.u0))
     # can't use Vector{T}(undef) as need to ensure no NaNs

--- a/src/solvers/wickerskamarock.jl
+++ b/src/solvers/wickerskamarock.jl
@@ -24,7 +24,7 @@ struct WickerSkamarockRungeKuttaCache{Nstages, RT, A}
     U::A
     F::A
 end
-function cache(prob::DiffEqBase.ODEProblem, alg::WickerSkamarockRungeKutta; kwargs...)
+function init_cache(prob::DiffEqBase.ODEProblem, alg::WickerSkamarockRungeKutta; kwargs...)
     U = similar(prob.u0)
     F = similar(prob.u0)
     return WickerSkamarockRungeKuttaCache(tableau(alg, eltype(F)), U, F)


### PR DESCRIPTION
This PR renames the `cache` method to `init_cache`, peeled off from #26.