### PR TITLE
Always use maxiter = 2

### DIFF
--- a/docs/src/plotting_utils.jl
+++ b/docs/src/plotting_utils.jl
@@ -87,7 +87,7 @@ function test_algs(
 
     for tab in tableaus
         prob = problem(test_case, tab)
-        alg = algorithm(test_case, tab)
+        alg = algorithm(tab)
         predicted_order = if super_convergence == tab
             CTS.theoretical_convergence_order(tab) + 1
         else

--- a/test/convergence_utils.jl
+++ b/test/convergence_utils.jl
@@ -60,7 +60,7 @@ end
 
 function test_convergence_order!(test_case, tab, results = Dict(); refinement_range)
     prob = problem(test_case, tab)
-    alg = algorithm(test_case, tab)
+    alg = algorithm(tab)
     expected_order = default_expected_order(alg, tab)
     cr = OCT.refinement_study(
         prob,

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -4,10 +4,9 @@ using Test
 problem(test_case, tab::CTS.AbstractIMEXARKTableau) = test_case.split_prob
 problem(test_case, tab) = test_case.prob
 
-function algorithm(test_case, tab)
+function algorithm(tab)
     return if tab isa CTS.AbstractIMEXARKTableau
-        max_iters = test_case.linear_implicit ? 1 : 2 # TODO: is 2 enough?
-        CTS.IMEXARKAlgorithm(tab, NewtonsMethod(; max_iters))
+        CTS.IMEXARKAlgorithm(tab, NewtonsMethod(; max_iters = 2))
     else
         tab
     end


### PR DESCRIPTION
This PR changes maxiter to 2 for all cases, so that we disentangle the alg prescription from the problem