### PR TITLE
Rename "Tableau"s to "AlgorithmName"s

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ClimaTimeSteppers"
 uuid = "595c0a79-7f3d-439a-bc5a-b232dc3bde79"
 authors = ["Climate Modeling Alliance"]
-version = "0.6.0"
+version = "0.7.0"
 
 [deps]
 CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"

--- a/docs/src/api/algorithms.md
+++ b/docs/src/api/algorithms.md
@@ -8,24 +8,21 @@ CurrentModule = ClimaTimeSteppers
 
 ```@docs
 ForwardEulerODEFunction
+AbstractAlgorithmConstraint
+Unconstrained
+SSPConstrained
+IMEXAlgorithm
+IMEXTableau
 ```
 
 ## IMEX SSP methods
 
 ```@docs
-IMEXSSPRKAlgorithm
 SSP433
 SSP222
 SSP332
 SSP333
 SSP322
-```
-
-## IMEX ARK methods
-
-```@docs
-IMEXARKAlgorithm
-IMEXARKTableau
 ```
 
 ## Low-Storage Runge--Kutta (LSRK) methods

--- a/docs/src/dev/report_gen.jl
+++ b/docs/src/dev/report_gen.jl
@@ -17,7 +17,7 @@ include(joinpath(cts_dir, "test", "problems.jl"))
     tab3 = (ARS233, ARS343, ARS443, IMKG342a, IMKG343a, DBM453)
     tabs = [tab1..., tab2..., tab3...]
     tabs = map(t -> t(), tabs)
-    get_alg = (tab, test_case) -> IMEXARKAlgorithm(tab, NewtonsMethod(; max_iters = test_case.linear_implicit ? 1 : 2))
+    get_alg = (tab, test_case) -> IMEXAlgorithm(tab, NewtonsMethod(; max_iters = test_case.linear_implicit ? 1 : 2))
     test_algs("IMEX ARK", get_alg, tabs, ark_analytic_nonlin_test_cts(Float64), 400)
     test_algs("IMEX ARK", get_alg, tabs, ark_analytic_sys_test_cts(Float64), 60)
     test_algs("IMEX ARK", get_alg, tabs, ark_analytic_test_cts(Float64), 16000; super_convergence = ARS121())

--- a/docs/src/dev/types.md
+++ b/docs/src/dev/types.md
@@ -19,5 +19,5 @@ import AbstractTrees as AT
 import InteractiveUtils as IU
 import ClimaTimeSteppers as CTS
 AT.children(x::Type) = IU.subtypes(x)
-AT.print_tree(CTS.AbstractTableau)
+AT.print_tree(CTS.AbstractAlgorithmName)
 ```

--- a/perf/benchmark.jl
+++ b/perf/benchmark.jl
@@ -5,7 +5,7 @@ using BenchmarkTools, DiffEqBase
 include(joinpath(pkgdir(CTS), "test", "problems.jl"))
 
 function main()
-    algorithm = CTS.IMEXARKAlgorithm(CTS.ARS343(), CTS.NewtonsMethod(; max_iters = 2))
+    algorithm = CTS.IMEXAlgorithm(CTS.ARS343(), CTS.NewtonsMethod(; max_iters = 2))
     dt = 0.01
     for problem in (split_linear_prob_wfact_split(), split_linear_prob_wfact_split_fe())
         integrator = DiffEqBase.init(problem, algorithm; dt)

--- a/perf/flame.jl
+++ b/perf/flame.jl
@@ -30,7 +30,7 @@ elseif problem_str == "fe"
 else
     error("Bad option")
 end
-algorithm = CTS.IMEXARKAlgorithm(ARS343(), NewtonsMethod(; max_iters = 2))
+algorithm = CTS.IMEXAlgorithm(ARS343(), NewtonsMethod(; max_iters = 2))
 dt = 0.01
 integrator = DiffEqBase.init(prob, algorithm; dt)
 cache = CTS.init_cache(prob, algorithm)

--- a/perf/jet.jl
+++ b/perf/jet.jl
@@ -15,7 +15,7 @@ end
 cts = joinpath(dirname(@__DIR__));
 include(joinpath(cts, "test", "problems.jl"))
 function config_integrators(problem)
-    algorithm = CTS.IMEXARKAlgorithm(ARS343(), NewtonsMethod(; max_iters = 2))
+    algorithm = CTS.IMEXAlgorithm(ARS343(), NewtonsMethod(; max_iters = 2))
     dt = 0.01
     integrator = DiffEqBase.init(problem, algorithm; dt)
     integrator.cache = CTS.init_cache(problem, algorithm)

--- a/src/ClimaTimeSteppers.jl
+++ b/src/ClimaTimeSteppers.jl
@@ -51,7 +51,7 @@ using LinearOperators
 using StaticArrays
 using CUDA
 
-export AbstractIMEXARKTableau
+export AbstractAlgorithmName, AbstractAlgorithmConstraint, Unconstrained, SSPConstrained
 
 array_device(::Union{Array, SArray, MArray}) = CPU()
 array_device(::CuArray) = CUDADevice()
@@ -66,18 +66,38 @@ include("operators.jl")
 
 abstract type DistributedODEAlgorithm <: DiffEqBase.AbstractODEAlgorithm end
 
-abstract type AbstractIMEXARKAlgorithm <: DistributedODEAlgorithm end
-
-abstract type AbstractTableau end
-abstract type AbstractIMEXARKTableau <: AbstractTableau end
-abstract type AbstractIMEXSSPARKTableau <: AbstractTableau end
+abstract type AbstractAlgorithmName end
 
 """
-    tableau(::DistributedODEAlgorithm)
+    AbstractAlgorithmConstraint
 
-Returns the tableau for a particular algorithm.
+A mechanism for restricting which operations can be performed by an algorithm
+for solving ODEs.
+
+For example, an unconstrained algorithm might compute a Runge-Kutta stage by
+taking linear combinations of tendencies; i.e., by adding quantities of the form
+`dt * tendency(state)`. On the other hand, a "strong stability preserving"
+algorithm can only take linear combinations of "incremented states"; i.e., it
+only adds quantities of the form `state + dt * coefficient * tendency(state)`.
 """
-function tableau end
+abstract type AbstractAlgorithmConstraint end
+
+"""
+    Unconstrained
+
+Indicates that an algorithm may perform any supported operations.
+"""
+struct Unconstrained <: AbstractAlgorithmConstraint end
+
+"""
+    SSPConstrained
+
+Indicates that an algorithm must be "strong stability preserving", which makes
+it easier to guarantee that the algorithm will preserve monotonicity properties
+satisfied by the initial state. For example, this ensures that the algorithm
+will be able to use limiters in a mathematically consistent way.
+"""
+struct SSPConstrained <: AbstractAlgorithmConstraint end
 
 SciMLBase.allowscomplex(alg::DistributedODEAlgorithm) = true
 include("integrators.jl")
@@ -92,7 +112,7 @@ n_stages_ntuple(::Type{<:NTuple{Nstages}}) where {Nstages} = Nstages
 n_stages_ntuple(::Type{<:SVector{Nstages}}) where {Nstages} = Nstages
 
 # Include concrete implementations
-include("solvers/imex_ark_tableaus.jl")
+include("solvers/imex_tableaus.jl")
 include("solvers/imex_ark.jl")
 include("solvers/imex_ssp.jl")
 include("solvers/multirate.jl")

--- a/src/solvers/imex_ssp.jl
+++ b/src/solvers/imex_ssp.jl
@@ -1,59 +1,4 @@
-export IMEXSSPRKAlgorithm
-
-#=
-U[i] = (1 - β[i-1]) * u + β[i-1] * (U[i-1] + dt * T_exp(U[i-1])) for i > 1 ==>
-    U[2] = (1 - β[1]) * u + β[1] * (U[1] + dt * T_exp(U[1])) =
-           u + dt * β[1] * T_exp(U[1])
-    U[3] = (1 - β[2]) * u + β[2] * (U[2] + dt * T_exp(U[2])) =
-           u +
-           dt * β[1] * β[2] * T_exp(U[1]) +
-           dt * β[2] * T_exp(U[2])
-    U[4] = (1 - β[3]) * u + β[3] * (U[3] + dt * T_exp(U[3])) =
-           u +
-           dt * β[1] * β[2] * Β[3] * T_exp(U[1]) +
-           dt * β[2] * Β[3] * T_exp(U[2]) +
-           dt * Β[3] * T_exp(U[3])
-    ...
-
-U[i] = u + ∑_{j = 1}^{i - 1} dt * a_exp[i, j] * T_exp(U[j]) ==>
-    a_exp = [
-        0                  0           0    …
-        β[1]               0           0    …
-        β[1] * β[2]        β[2]        0    …
-        β[1] * β[2] * β[3] β[2] * β[3] β[3] …
-        ⋮                  ⋮            ⋮    ⋱
-    ] ==>
-    a_exp[i+1:s+1, i] = cumprod(β[i:s])
-=#
-
-"""
-    IMEXSSPRKAlgorithm(
-        tabname::AbstractTableau,
-        newtons_method
-    ) <: DistributedODEAlgorithm
-
-A generic implementation of an IMEX SSP RK algorithm that can handle arbitrary
-Butcher tableaus.
-"""
-struct IMEXSSPRKAlgorithm{B, T <: IMEXARKTableau, NM} <: DistributedODEAlgorithm
-    β::B
-    tab::T
-    newtons_method::NM
-end
-function IMEXSSPRKAlgorithm(tabname::AbstractTableau, newtons_method)
-    tab = tableau(tabname)
-    (; a_exp, b_exp) = tab
-    â_exp = vcat(a_exp, b_exp')
-    β = diag(â_exp, -1)
-    for i in 1:length(β)
-        if â_exp[(i + 1):end, i] != cumprod(β[i:end])
-            error("Tableau does not satisfy requirements for an SSP RK method")
-        end
-    end
-    IMEXSSPRKAlgorithm(β, tab, newtons_method)
-end
-
-struct IMEXSSPRKCache{U, SCI, Γ, NMC}
+struct IMEXSSPRKCache{U, SCI, B, Γ, NMC}
     U::U
     U_exp::U
     U_lim::U
@@ -61,15 +6,16 @@ struct IMEXSSPRKCache{U, SCI, Γ, NMC}
     T_exp::U
     T_imp::SCI # sparse container of length s
     temp::U
+    β::B
     γ::Γ
     newtons_method_cache::NMC
 end
 
-function init_cache(prob::DiffEqBase.AbstractODEProblem, alg::IMEXSSPRKAlgorithm; kwargs...)
+function init_cache(prob::DiffEqBase.AbstractODEProblem, alg::IMEXAlgorithm{SSPConstrained}; kwargs...)
     (; u0, f) = prob
     (; T_imp!) = f
-    (; tab, newtons_method) = alg
-    (; a_exp, b_exp, a_imp, b_imp) = tab
+    (; tableau, newtons_method) = alg
+    (; a_exp, b_exp, a_imp, b_imp) = tableau
     s = length(b_exp)
     inds = ntuple(i -> i, s)
     inds_T_imp = filter(i -> !all(iszero, a_imp[:, i]) || !iszero(b_imp[i]), inds)
@@ -80,20 +26,38 @@ function init_cache(prob::DiffEqBase.AbstractODEProblem, alg::IMEXSSPRKAlgorithm
     U_lim = similar(u0)
     T_imp = SparseContainer(map(i -> similar(u0), collect(1:length(inds_T_imp))), inds_T_imp)
     temp = similar(u0)
+    â_exp = vcat(a_exp, b_exp')
+    β = diag(â_exp, -1)
+    for i in 1:length(β)
+        if â_exp[(i + 1):end, i] != cumprod(β[i:end])
+            error("The SSPConstrained IMEXAlgorithm currently only supports an \
+                   IMEXTableau that specifies a \"low-storage\" IMEX SSPRK \
+                   algorithm, where the canonical Shu-Osher representation of \
+                   the i-th explicit stage for i > 1 must have the form U[i] = \
+                   (1 - β[i-1]) * u + β[i-1] * (U[i-1] + dt * T_exp(U[i-1])). \
+                   So, it must be possible to express vcat(a_exp, b_exp') as\n \
+                   0                  0           0    …\n \
+                   β[1]               0           0    …\n \
+                   β[1] * β[2]        β[2]        0    …\n \
+                   β[1] * β[2] * β[3] β[2] * β[3] β[3] …\n \
+                   ⋮                  ⋮            ⋮    ⋱\n \
+                   The given IMEXTableau does not satisfy this property.")
+        end
+    end
     γs = unique(filter(!iszero, diag(a_imp)))
     γ = length(γs) == 1 ? γs[1] : nothing # TODO: This could just be a constant.
     jac_prototype = has_jac(T_imp!) ? T_imp!.jac_prototype : nothing
     newtons_method_cache = isnothing(T_imp!) ? nothing : allocate_cache(newtons_method, u0, jac_prototype)
-    return IMEXSSPRKCache(U, U_exp, U_lim, T_lim, T_exp, T_imp, temp, γ, newtons_method_cache)
+    return IMEXSSPRKCache(U, U_exp, U_lim, T_lim, T_exp, T_imp, temp, β, γ, newtons_method_cache)
 end
 
 function step_u!(integrator, cache::IMEXSSPRKCache)
     (; u, p, t, dt, sol, alg) = integrator
     (; f) = sol.prob
     (; T_lim!, T_exp!, T_imp!, lim!, dss!, stage_callback!) = f
-    (; β, tab, newtons_method) = alg
-    (; a_imp, b_imp, c_exp, c_imp) = tab
-    (; U, U_lim, U_exp, T_lim, T_exp, T_imp, temp, γ, newtons_method_cache) = cache
+    (; name, tableau, newtons_method) = alg
+    (; a_imp, b_imp, c_exp, c_imp) = tableau
+    (; U, U_lim, U_exp, T_lim, T_exp, T_imp, temp, β, γ, newtons_method_cache) = cache
     s = length(b_imp)
 
     if !isnothing(T_imp!)
@@ -101,11 +65,7 @@ function step_u!(integrator, cache::IMEXSSPRKCache)
             newtons_method,
             newtons_method_cache,
             NewTimeStep(t),
-            jacobian ->
-                isnothing(γ) ? error("The tableau does not specify a unique value of γ for the \
-                                      duration of each time step; do not update based on the \
-                                      NewTimeStep signal when using this tableau.") :
-                T_imp!.Wfact(jacobian, u, p, dt * γ, t),
+            jacobian -> isnothing(γ) ? sdirk_error(name) : T_imp!.Wfact(jacobian, u, p, dt * γ, t),
         )
     end
 

--- a/src/solvers/imex_tableaus.jl
+++ b/src/solvers/imex_tableaus.jl
@@ -1,3 +1,4 @@
+export IMEXTableau, IMEXAlgorithm
 export ARS111, ARS121, ARS122, ARS233, ARS232, ARS222, ARS343, ARS443
 export IMKG232a, IMKG232b, IMKG242a, IMKG242b, IMKG243a, IMKG252a, IMKG252b
 export IMKG253a, IMKG253b, IMKG254a, IMKG254b, IMKG254c, IMKG342a, IMKG343a
@@ -6,18 +7,24 @@ export SSP222, SSP322, SSP332, SSP333, SSP433
 
 using StaticArrays: @SArray, SMatrix, sacollect
 
-################################################################################
+abstract type IMEXAlgorithmName <: AbstractAlgorithmName end
+abstract type IMEXSSPRKAlgorithmName <: IMEXAlgorithmName end
+default_constraint(::IMEXAlgorithmName) = Unconstrained()
+default_constraint(::IMEXSSPRKAlgorithmName) = SSPConstrained()
 
 """
-    IMEXARKTableau(; a_exp, b_exp, c_exp, a_imp, b_imp, c_imp)
+    IMEXTableau(; a_exp, b_exp, c_exp, a_imp, b_imp, c_imp)
 
-Generates an `IMEXARKTableau` struct from an IMEX ARK Butcher tableau. Only
-`a_exp` and `a_imp` are required arguments; the default values for `b_exp` and
-`b_imp` assume that the algorithm is FSAL (first same as last), and the default
-values for `c_exp` and `c_imp` assume that the algorithm is internally
-consistent.
+A wrapper for an IMEX Butcher tableau (or, more accurately, a pair of Butcher
+tableaus, one for explicit tendencies and the other for implicit tendencies).
+Only `a_exp` and `a_imp` are required arguments; the default values for `b_exp`
+and `b_imp` assume that the algorithm is FSAL (first same as last), and the
+default values for `c_exp` and `c_imp` assume that it is internally consistent.
+
+The explicit tableau must be strictly lower triangular, and the implicit tableau
+must be lower triangular (only DIRK algorithms are currently supported).
 """
-struct IMEXARKTableau{VS <: StaticArrays.StaticArray, MS <: StaticArrays.StaticArray} <: AbstractTableau
+struct IMEXTableau{VS <: StaticArrays.StaticArray, MS <: StaticArrays.StaticArray}
     a_exp::MS # matrix of size s×s
     b_exp::VS # vector of length s
     c_exp::VS # vector of length s
@@ -25,7 +32,7 @@ struct IMEXARKTableau{VS <: StaticArrays.StaticArray, MS <: StaticArrays.StaticA
     b_imp::VS # vector of length s
     c_imp::VS # vector of length s
 end
-function IMEXARKTableau(;
+function IMEXTableau(;
     a_exp,
     b_exp = a_exp[end, :],
     c_exp = vec(sum(a_exp; dims = 2)),
@@ -33,11 +40,47 @@ function IMEXARKTableau(;
     b_imp = a_imp[end, :],
     c_imp = vec(sum(a_imp; dims = 2)),
 )
+    @assert all(iszero, UpperTriangular(a_exp))
+    @assert all(iszero, UpperTriangular(a_imp) - Diagonal(a_imp))
+
     # TODO: add generic promote_eltype
     a_exp, a_imp = promote(a_exp, a_imp)
     b_exp, b_imp, c_exp, c_imp = promote(b_exp, b_imp, c_exp, c_imp)
-    return IMEXARKTableau(a_exp, b_exp, c_exp, a_imp, b_imp, c_imp)
+    return IMEXTableau(a_exp, b_exp, c_exp, a_imp, b_imp, c_imp)
 end
+
+"""
+    IMEXAlgorithm(tableau, newtons_method, [constraint])
+    IMEXAlgorithm(name, newtons_method, [constraint])
+    [Name](newtons_method)
+
+Constructs an IMEX algorithm for solving ODEs, with an optional name and
+constraint. The first constructor accepts any `IMEXTableau` and an optional
+constraint, leaving the algorithm unnamed. The second constructor automatically
+determines the tableau and the default constraint from the algorithm name, which
+must be an `IMEXAlgorithmName`.
+
+The last constructor matches the notation of `OrdinaryDiffEq.jl`; it dispatches
+to the second constructor by returning `IMEXAlgorithm(Name(), newtons_method)`.
+"""
+struct IMEXAlgorithm{
+    C <: AbstractAlgorithmConstraint,
+    N <: Union{Nothing, IMEXAlgorithmName},
+    T <: IMEXTableau,
+    NM <: NewtonsMethod,
+} <: DistributedODEAlgorithm
+    constraint::C
+    name::N
+    tableau::T
+    newtons_method::NM
+end
+IMEXAlgorithm(tableau::IMEXTableau, newtons_method, constraint = Unconstrained()) =
+    IMEXAlgorithm(constraint, nothing, tableau, newtons_method)
+IMEXAlgorithm(name::IMEXAlgorithmName, newtons_method, constraint = default_constraint(name)) =
+    IMEXAlgorithm(constraint, name, IMEXTableau(name), newtons_method)
+(::Type{Name})(newtons_method::NewtonsMethod) where {Name <: IMEXAlgorithmName} = IMEXAlgorithm(Name(), newtons_method)
+
+################################################################################
 
 # ARS algorithms
 
@@ -57,10 +100,10 @@ The Forward-Backward (1,1,1) implicit-explicit (IMEX) Runge-Kutta scheme of
 
 This is equivalent to the `OrdinaryDiffEq.IMEXEuler` algorithm.
 """
-struct ARS111 <: AbstractIMEXARKTableau end
+struct ARS111 <: IMEXAlgorithmName end
 
-function tableau(::ARS111)
-    IMEXARKTableau(; a_exp = @SArray([0 0; 1 0]), a_imp = @SArray([0 0; 0 1]))
+function IMEXTableau(::ARS111)
+    IMEXTableau(; a_exp = @SArray([0 0; 1 0]), a_imp = @SArray([0 0; 0 1]))
 end
 
 """
@@ -71,15 +114,15 @@ The Forward-Backward (1,2,1) implicit-explicit (IMEX) Runge-Kutta scheme of
 
 This is equivalent to the `OrdinaryDiffEq.IMEXEulerARK` algorithm.
 """
-struct ARS121 <: AbstractIMEXARKTableau end
+struct ARS121 <: IMEXAlgorithmName end
 
-function tableau(::ARS121)
-    IMEXARKTableau(; a_exp = @SArray([0 0; 1 0]), b_exp = @SArray([0, 1]), a_imp = @SArray([0 0; 0 1]))
+function IMEXTableau(::ARS121)
+    IMEXTableau(; a_exp = @SArray([0 0; 1 0]), b_exp = @SArray([0, 1]), a_imp = @SArray([0 0; 0 1]))
 end
 
-struct ARS122 <: AbstractIMEXARKTableau end
-function tableau(::ARS122)
-    IMEXARKTableau(;
+struct ARS122 <: IMEXAlgorithmName end
+function IMEXTableau(::ARS122)
+    IMEXTableau(;
         a_exp = @SArray([0 0; 1/2 0]),
         b_exp = @SArray([0, 1]),
         a_imp = @SArray([0 0; 0 1/2]),
@@ -87,10 +130,10 @@ function tableau(::ARS122)
     )
 end
 
-struct ARS233 <: AbstractIMEXARKTableau end
-function tableau(::ARS233)
+struct ARS233 <: IMEXAlgorithmName end
+function IMEXTableau(::ARS233)
     γ = 1 / 2 + √3 / 6
-    IMEXARKTableau(;
+    IMEXTableau(;
         a_exp = @SArray([
             0 0 0
             γ 0 0
@@ -112,11 +155,11 @@ end
 The Forward-Backward (2,3,2) implicit-explicit (IMEX) Runge-Kutta scheme of
 [ARS1997](@cite), section 2.5.
 """
-struct ARS232 <: AbstractIMEXARKTableau end
-function tableau(::ARS232)
+struct ARS232 <: IMEXAlgorithmName end
+function IMEXTableau(::ARS232)
     γ = 1 - √2 / 2
     δ = -2√2 / 3
-    IMEXARKTableau(;
+    IMEXTableau(;
         a_exp = @SArray([
             0 0 0
             γ 0 0
@@ -131,11 +174,11 @@ function tableau(::ARS232)
     )
 end
 
-struct ARS222 <: AbstractIMEXARKTableau end
-function tableau(::ARS222)
+struct ARS222 <: IMEXAlgorithmName end
+function IMEXTableau(::ARS222)
     γ = 1 - √2 / 2
     δ = 1 - 1 / 2γ
-    IMEXARKTableau(; a_exp = @SArray([
+    IMEXTableau(; a_exp = @SArray([
         0 0 0
         γ 0 0
         δ (1-δ) 0
@@ -152,8 +195,8 @@ end
 The L-stable, third-order (3,4,3) implicit-explicit (IMEX) Runge-Kutta scheme of
 [ARS1997](@cite), section 2.7.
 """
-struct ARS343 <: AbstractIMEXARKTableau end
-function tableau(::ARS343)
+struct ARS343 <: IMEXAlgorithmName end
+function IMEXTableau(::ARS343)
     γ = 0.4358665215084590
     a42 = 0.5529291480359398
     a43 = a42
@@ -165,7 +208,7 @@ function tableau(::ARS343)
         (-1 + 9 / 2 * γ - 3 / 2 * γ^2) * a42 + (-11 / 4 + 21 / 2 * γ - 15 / 4 * γ^2) * a43 + 4 - 25 / 2 * γ +
         9 / 2 * γ^2
     a41 = 1 - a42 - a43
-    return IMEXARKTableau(;
+    IMEXTableau(;
         a_exp = @SArray([
             0 0 0 0
             γ 0 0 0
@@ -182,9 +225,9 @@ function tableau(::ARS343)
     )
 end
 
-struct ARS443 <: AbstractIMEXARKTableau end
-function tableau(::ARS443)
-    IMEXARKTableau(;
+struct ARS443 <: IMEXAlgorithmName end
+function IMEXTableau(::ARS443)
+    IMEXTableau(;
         a_exp = @SArray([
             0 0 0 0 0
             1/2 0 0 0 0
@@ -230,55 +273,55 @@ end
 imkg_exp(i, j, α, β) = i == j + 1 ? α[j] : (i > 2 && j == 1 ? β[i - 2] : 0)
 imkg_imp(i, j, α̂, β, δ̂) =
     i == j + 1 ? α̂[j] : (i > 2 && j == 1 ? β[i - 2] : (1 < i <= length(α̂) && i == j ? δ̂[i - 1] : 0))
-function make_IMKGTableau(α, α̂, δ̂, β = ntuple(_ -> 0, length(δ̂)))
+function IMKGTableau(α, α̂, δ̂, β = ntuple(_ -> 0, length(δ̂)))
     s = length(α̂) + 1
     type = SMatrix{s, s}
-    return IMEXARKTableau(;
+    return IMEXTableau(;
         a_exp = sacollect(type, imkg_exp(i, j, α, β) for i in 1:s, j in 1:s),
         a_imp = sacollect(type, imkg_imp(i, j, α̂, β, δ̂) for i in 1:s, j in 1:s),
     )
 end
 
-struct IMKG232a <: AbstractIMEXARKTableau end
-function tableau(::IMKG232a)
-    make_IMKGTableau((1 / 2, 1 / 2, 1), (0, -1 / 2 + √2 / 2, 1), (1 - √2 / 2, 1 - √2 / 2))
+struct IMKG232a <: IMEXAlgorithmName end
+function IMEXTableau(::IMKG232a)
+    IMKGTableau((1 / 2, 1 / 2, 1), (0, -1 / 2 + √2 / 2, 1), (1 - √2 / 2, 1 - √2 / 2))
 end
 
-struct IMKG232b <: AbstractIMEXARKTableau end
-function tableau(::IMKG232b)
-    make_IMKGTableau((1 / 2, 1 / 2, 1), (0, -1 / 2 - √2 / 2, 1), (1 + √2 / 2, 1 + √2 / 2))
+struct IMKG232b <: IMEXAlgorithmName end
+function IMEXTableau(::IMKG232b)
+    IMKGTableau((1 / 2, 1 / 2, 1), (0, -1 / 2 - √2 / 2, 1), (1 + √2 / 2, 1 + √2 / 2))
 end
 
-struct IMKG242a <: AbstractIMEXARKTableau end
-function tableau(::IMKG242a)
-    make_IMKGTableau((1 / 4, 1 / 3, 1 / 2, 1), (0, 0, -1 / 2 + √2 / 2, 1), (0, 1 - √2 / 2, 1 - √2 / 2))
+struct IMKG242a <: IMEXAlgorithmName end
+function IMEXTableau(::IMKG242a)
+    IMKGTableau((1 / 4, 1 / 3, 1 / 2, 1), (0, 0, -1 / 2 + √2 / 2, 1), (0, 1 - √2 / 2, 1 - √2 / 2))
 end
 
-struct IMKG242b <: AbstractIMEXARKTableau end
-function tableau(::IMKG242b)
-    make_IMKGTableau((1 / 4, 1 / 3, 1 / 2, 1), (0, 0, -1 / 2 - √2 / 2, 1), (0, 1 + √2 / 2, 1 + √2 / 2))
+struct IMKG242b <: IMEXAlgorithmName end
+function IMEXTableau(::IMKG242b)
+    IMKGTableau((1 / 4, 1 / 3, 1 / 2, 1), (0, 0, -1 / 2 - √2 / 2, 1), (0, 1 + √2 / 2, 1 + √2 / 2))
 end
 
 # The paper uses √3/6 for α̂[3], which also seems to work.
-struct IMKG243a <: AbstractIMEXARKTableau end
-function tableau(::IMKG243a)
-    make_IMKGTableau((1 / 4, 1 / 3, 1 / 2, 1), (0, 1 / 6, -√3 / 6, 1), (1 / 2 + √3 / 6, 1 / 2 + √3 / 6, 1 / 2 + √3 / 6))
+struct IMKG243a <: IMEXAlgorithmName end
+function IMEXTableau(::IMKG243a)
+    IMKGTableau((1 / 4, 1 / 3, 1 / 2, 1), (0, 1 / 6, -√3 / 6, 1), (1 / 2 + √3 / 6, 1 / 2 + √3 / 6, 1 / 2 + √3 / 6))
 end
 
-struct IMKG252a <: AbstractIMEXARKTableau end
-function tableau(::IMKG252a)
-    make_IMKGTableau((1 / 4, 1 / 6, 3 / 8, 1 / 2, 1), (0, 0, 0, -1 / 2 + √2 / 2, 1), (0, 0, 1 - √2 / 2, 1 - √2 / 2))
+struct IMKG252a <: IMEXAlgorithmName end
+function IMEXTableau(::IMKG252a)
+    IMKGTableau((1 / 4, 1 / 6, 3 / 8, 1 / 2, 1), (0, 0, 0, -1 / 2 + √2 / 2, 1), (0, 0, 1 - √2 / 2, 1 - √2 / 2))
 end
 
-struct IMKG252b <: AbstractIMEXARKTableau end
-function tableau(::IMKG252b)
-    make_IMKGTableau((1 / 4, 1 / 6, 3 / 8, 1 / 2, 1), (0, 0, 0, -1 / 2 - √2 / 2, 1), (0, 0, 1 + √2 / 2, 1 + √2 / 2))
+struct IMKG252b <: IMEXAlgorithmName end
+function IMEXTableau(::IMKG252b)
+    IMKGTableau((1 / 4, 1 / 6, 3 / 8, 1 / 2, 1), (0, 0, 0, -1 / 2 - √2 / 2, 1), (0, 0, 1 + √2 / 2, 1 + √2 / 2))
 end
 
 # The paper uses 0.08931639747704086 for α̂[3], which also seems to work.
-struct IMKG253a <: AbstractIMEXARKTableau end
-function tableau(::IMKG253a)
-    make_IMKGTableau(
+struct IMKG253a <: IMEXAlgorithmName end
+function IMEXTableau(::IMKG253a)
+    IMKGTableau(
         (1 / 4, 1 / 6, 3 / 8, 1 / 2, 1),
         (0, 0, √3 / 4 * (1 - √3 / 3) * ((1 + √3 / 3)^2 - 2), √3 / 6, 1),
         (0, 1 / 2 - √3 / 6, 1 / 2 - √3 / 6, 1 / 2 - √3 / 6),
@@ -286,42 +329,42 @@ function tableau(::IMKG253a)
 end
 
 # The paper uses 1.2440169358562922 for α̂[3], which also seems to work.
-struct IMKG253b <: AbstractIMEXARKTableau end
-function tableau(::IMKG253b)
-    make_IMKGTableau(
+struct IMKG253b <: IMEXAlgorithmName end
+function IMEXTableau(::IMKG253b)
+    IMKGTableau(
         (1 / 4, 1 / 6, 3 / 8, 1 / 2, 1),
         (0, 0, √3 / 4 * (1 + √3 / 3) * ((1 - √3 / 3)^2 - 2), -√3 / 6, 1),
         (0, 1 / 2 + √3 / 6, 1 / 2 + √3 / 6, 1 / 2 + √3 / 6),
     )
 end
 
-struct IMKG254a <: AbstractIMEXARKTableau end
-function tableau(::IMKG254a)
-    make_IMKGTableau((1 / 4, 1 / 6, 3 / 8, 1 / 2, 1), (0, -3 / 10, 5 / 6, -3 / 2, 1), (-1 / 2, 1, 1, 2))
+struct IMKG254a <: IMEXAlgorithmName end
+function IMEXTableau(::IMKG254a)
+    IMKGTableau((1 / 4, 1 / 6, 3 / 8, 1 / 2, 1), (0, -3 / 10, 5 / 6, -3 / 2, 1), (-1 / 2, 1, 1, 2))
 end
 
-struct IMKG254b <: AbstractIMEXARKTableau end
-function tableau(::IMKG254b)
-    make_IMKGTableau((1 / 4, 1 / 6, 3 / 8, 1 / 2, 1), (0, -1 / 20, 5 / 4, -1 / 2, 1), (-1 / 2, 1, 1, 1))
+struct IMKG254b <: IMEXAlgorithmName end
+function IMEXTableau(::IMKG254b)
+    IMKGTableau((1 / 4, 1 / 6, 3 / 8, 1 / 2, 1), (0, -1 / 20, 5 / 4, -1 / 2, 1), (-1 / 2, 1, 1, 1))
 end
 
-struct IMKG254c <: AbstractIMEXARKTableau end
-function tableau(::IMKG254c)
-    make_IMKGTableau((1 / 4, 1 / 6, 3 / 8, 1 / 2, 1), (0, 1 / 20, 5 / 36, 1 / 3, 1), (1 / 6, 1 / 6, 1 / 6, 1 / 6))
+struct IMKG254c <: IMEXAlgorithmName end
+function IMEXTableau(::IMKG254c)
+    IMKGTableau((1 / 4, 1 / 6, 3 / 8, 1 / 2, 1), (0, 1 / 20, 5 / 36, 1 / 3, 1), (1 / 6, 1 / 6, 1 / 6, 1 / 6))
 end
 
 # The paper and HOMME completely disagree on this algorithm. Since the version
 # in the paper is not "342" (it appears to be "332"), the version from HOMME is
 # used here.
-# const IMKG342a = make_IMKGTableau(
+# const IMKG342a = IMKGTableau(
 #     (0, 1/3, 1/3, 3/4),
 #     (0, -1/6 - √3/6, -1/6 - √3/6, 3/4),
 #     (0, 1/2 + √3/6, 1/2 + √3/6),
 #     (1/3, 1/3, 1/4),
 # )
-struct IMKG342a <: AbstractIMEXARKTableau end
-function tableau(::IMKG342a)
-    make_IMKGTableau(
+struct IMKG342a <: IMEXAlgorithmName end
+function IMEXTableau(::IMKG342a)
+    IMKGTableau(
         (1 / 4, 2 / 3, 1 / 3, 3 / 4),
         (0, 1 / 6 - √3 / 6, -1 / 6 - √3 / 6, 3 / 4),
         (0, 1 / 2 + √3 / 6, 1 / 2 + √3 / 6),
@@ -329,25 +372,25 @@ function tableau(::IMKG342a)
     )
 end
 
-struct IMKG343a <: AbstractIMEXARKTableau end
-function tableau(::IMKG343a)
-    make_IMKGTableau((1 / 4, 2 / 3, 1 / 3, 3 / 4), (0, -1 / 3, -2 / 3, 3 / 4), (-1 / 3, 1, 1), (0, 1 / 3, 1 / 4))
+struct IMKG343a <: IMEXAlgorithmName end
+function IMEXTableau(::IMKG343a)
+    IMKGTableau((1 / 4, 2 / 3, 1 / 3, 3 / 4), (0, -1 / 3, -2 / 3, 3 / 4), (-1 / 3, 1, 1), (0, 1 / 3, 1 / 4))
 end
 
 # The paper and HOMME completely disagree on this algorithm, but neither version
 # is "353" (they appear to be "343" and "354", respectively).
-# struct IMKG353a <: AbstractIMEXARKTableau end
-# function tableau(::IMKG353a)
-#     make_IMKGTableau(
+# struct IMKG353a <: IMEXAlgorithmName end
+# function IMEXTableau(::IMKG353a)
+#     IMKGTableau(
 #         (1/4, 2/3, 1/3, 3/4),
 #         (0, -359/600, -559/600, 3/4),
 #         (-1.1678009811335388, 253/200, 253/200),
 #         (0, 1/3, 1/4),
 #     )
 # end
-# struct IMKG353a <: AbstractIMEXARKTableau end
-# function tableau(::IMKG353a)
-#     make_IMKGTableau(
+# struct IMKG353a <: IMEXAlgorithmName end
+# function IMEXTableau(::IMKG353a)
+#     IMKGTableau(
 #         (-0.017391304347826087, -23/25, 5/3, 1/3, 3/4),
 #         (0.3075640504095504, -1.2990164859879263, 751/600, -49/60, 3/4),
 #         (-0.2981612530370581, 83/200, 83/200, 23/20),
@@ -359,9 +402,9 @@ end
 # "253"), and this algorithm is missing from HOMME (or, more precisely, the
 # tableau for IMKG353a is mistakenly used to define IMKG354a, and the tableau
 # for IMKG354a is not specified).
-# struct IMKG354a <: AbstractIMEXARKTableau end
-# function tableau(::IMKG354a)
-#     make_IMKGTableau(
+# struct IMKG354a <: IMEXAlgorithmName end
+# function IMEXTableau(::IMKG354a)
+#     IMKGTableau(
 #         (1/5, 1/5, 2/3, 1/3, 3/4),
 #         (0, 0, 11/30, -2/3, 3/4),
 #         (0, 2/4, 2/5, 1),
@@ -378,10 +421,10 @@ end
 
 # The algorithm has 4 implicit stages, 5 overall stages, and 3rd order accuracy.
 
-struct DBM453 <: AbstractIMEXARKTableau end
-function tableau(::DBM453)
+struct DBM453 <: IMEXAlgorithmName end
+function IMEXTableau(::DBM453)
     γ = 0.32591194130117247
-    IMEXARKTableau(;
+    IMEXTableau(;
         a_exp = @SArray(
             [
                 0 0 0 0 0
@@ -413,9 +456,9 @@ end
 
 # The algorithm has 5 implicit stages, 6 overall stages, and 2rd order accuracy.
 
-struct HOMMEM1 <: AbstractIMEXARKTableau end
-function tableau(::HOMMEM1)
-    IMEXARKTableau(;
+struct HOMMEM1 <: IMEXAlgorithmName end
+function IMEXTableau(::HOMMEM1)
+    IMEXTableau(;
         a_exp = @SArray([
             0 0 0 0 0 0
             1/5 0 0 0 0 0
@@ -444,10 +487,10 @@ end
 
 https://link.springer.com/content/pdf/10.1007/BF02728986.pdf, Table II
 """
-struct SSP222 <: AbstractIMEXSSPARKTableau end
-function tableau(::SSP222)
+struct SSP222 <: IMEXSSPRKAlgorithmName end
+function IMEXTableau(::SSP222)
     γ = 1 - √2 / 2
-    return IMEXARKTableau(;
+    return IMEXTableau(;
         a_exp = @SArray([
             0 0
             1 0
@@ -466,9 +509,9 @@ end
 
 https://link.springer.com/content/pdf/10.1007/BF02728986.pdf, Table III
 """
-struct SSP322 <: AbstractIMEXSSPARKTableau end
-function tableau(::SSP322)
-    return IMEXARKTableau(;
+struct SSP322 <: IMEXSSPRKAlgorithmName end
+function IMEXTableau(::SSP322)
+    return IMEXTableau(;
         a_exp = @SArray([
             0 0 0
             0 0 0
@@ -489,10 +532,10 @@ end
 
 https://link.springer.com/content/pdf/10.1007/BF02728986.pdf, Table V
 """
-struct SSP332 <: AbstractIMEXSSPARKTableau end
-function tableau(::SSP332)
+struct SSP332 <: IMEXSSPRKAlgorithmName end
+function IMEXTableau(::SSP332)
     γ = 1 - √2 / 2
-    return IMEXARKTableau(;
+    return IMEXTableau(;
         a_exp = @SArray([
             0 0 0
             1 0 0
@@ -509,20 +552,21 @@ function tableau(::SSP332)
 end
 
 """
-    SSP333(; β = (3 + sqrt(3)) / 6)
+    SSP333([β])
 
 Family of SSP333 algorithms parametrized by the value β, from Section 3.2 of
-https://arxiv.org/pdf/1702.04621.pdf. The default value of β results in an SDIRK
-algorithm, which is also called SSP3(333)c in
+https://arxiv.org/pdf/1702.04621.pdf. The default value of β, 1/2 + √3/6,
+results in an SDIRK algorithm, which is also called SSP3(333)c in
 https://gmd.copernicus.org/articles/11/1497/2018/gmd-11-1497-2018.pdf.
 """
-Base.@kwdef struct SSP333{FT} <: AbstractIMEXSSPARKTableau
-    β::FT = 1 / 2 + √3 / 6
+struct SSP333{FT} <: IMEXSSPRKAlgorithmName
+    β::FT
+    SSP333(β::AbstractFloat = 1 / 2 + √3 / 6) = new{typeof(β)}(β)
 end
-function tableau((; β)::SSP333)
+function IMEXTableau((; β)::SSP333)
     @assert β > 1 / 2
     γ = (2β^2 - 3β / 2 + 1 / 3) / (2 - 4β)
-    return IMEXARKTableau(;
+    return IMEXTableau(;
         a_exp = @SArray([
             0 0 0
             1 0 0
@@ -543,12 +587,12 @@ end
 
 https://link.springer.com/content/pdf/10.1007/BF02728986.pdf, Table VI
 """
-struct SSP433 <: AbstractIMEXSSPARKTableau end
-function tableau(::SSP433)
+struct SSP433 <: IMEXSSPRKAlgorithmName end
+function IMEXTableau(::SSP433)
     α = 0.24169426078821
     β = 0.06042356519705
     η = 0.12915286960590
-    return IMEXARKTableau(;
+    return IMEXTableau(;
         a_exp = @SArray([
             0 0 0 0
             0 0 0 0

--- a/src/solvers/imex_tableaus.jl
+++ b/src/solvers/imex_tableaus.jl
@@ -78,7 +78,14 @@ IMEXAlgorithm(tableau::IMEXTableau, newtons_method, constraint = Unconstrained()
     IMEXAlgorithm(constraint, nothing, tableau, newtons_method)
 IMEXAlgorithm(name::IMEXAlgorithmName, newtons_method, constraint = default_constraint(name)) =
     IMEXAlgorithm(constraint, name, IMEXTableau(name), newtons_method)
-(::Type{Name})(newtons_method::NewtonsMethod) where {Name <: IMEXAlgorithmName} = IMEXAlgorithm(Name(), newtons_method)
+
+# If all AbstractAlgorithmNames were singletons, we could make type-based
+# functors, but some AbstractAlgorithmNames have parameters (e.g., SSP333)
+
+# (::Type{Name})(newtons_method::NewtonsMethod) where {Name <: IMEXAlgorithmName} = IMEXAlgorithm(Name(), newtons_method)
+
+#= Convenience constructor =#
+(name::IMEXAlgorithmName)(newtons_method::NewtonsMethod) = IMEXAlgorithm(name, newtons_method)
 
 ################################################################################
 
@@ -559,9 +566,8 @@ https://arxiv.org/pdf/1702.04621.pdf. The default value of β, 1/2 + √3/6,
 results in an SDIRK algorithm, which is also called SSP3(333)c in
 https://gmd.copernicus.org/articles/11/1497/2018/gmd-11-1497-2018.pdf.
 """
-struct SSP333{FT} <: IMEXSSPRKAlgorithmName
-    β::FT
-    SSP333(β::AbstractFloat = 1 / 2 + √3 / 6) = new{typeof(β)}(β)
+Base.@kwdef struct SSP333{FT <: AbstractFloat} <: IMEXSSPRKAlgorithmName
+    β::FT = 1 / 2 + √3 / 6
 end
 function IMEXTableau((; β)::SSP333)
     @assert β > 1 / 2

--- a/test/convergence_orders.jl
+++ b/test/convergence_orders.jl
@@ -38,8 +38,6 @@ second_order_tableau() = [
 third_order_tableau() = [ARS233, ARS343, ARS443, IMKG342a, IMKG343a, DBM453, SSP333, SSP433]
 
 import OrdinaryDiffEq as ODE
-import ClimaTimeSteppers as CTS
-ODE.alg_order(alg::CTS.IMEXARKAlgorithm) = ODE.alg_order(alg.tab)
 
 for m in first_order_tableau()
     @eval ODE.alg_order(::$m) = 1

--- a/test/convergence_utils.jl
+++ b/test/convergence_utils.jl
@@ -52,8 +52,7 @@ function convergence_order(prob, sol, method, dts; kwargs...)
     return order_est
 end
 
-default_expected_order(alg, tab::CTS.AbstractIMEXARKTableau) = ODE.alg_order(tab)
-default_expected_order(alg, tab::CTS.AbstractIMEXSSPARKTableau) = ODE.alg_order(tab)
+default_expected_order(alg, tab::CTS.AbstractAlgorithmName) = ODE.alg_order(tab)
 # default_expected_order(alg, tab) = ODE.alg_order(alg)
 
 function test_convergence_order!(test_case, tab, results = Dict(); refinement_range)

--- a/test/single_column_ARS_test.jl
+++ b/test/single_column_ARS_test.jl
@@ -281,12 +281,12 @@ end
 
 
     algorithms = (
-        CTS.IMEXARKAlgorithm(ARS111(), NewtonsMethod(; max_iters = 1)),
-        CTS.IMEXARKAlgorithm(ARS121(), NewtonsMethod(; max_iters = 1)),
-        CTS.IMEXARKAlgorithm(ARS122(), NewtonsMethod(; max_iters = 1)),
-        CTS.IMEXARKAlgorithm(ARS232(), NewtonsMethod(; max_iters = 1)),
-        CTS.IMEXARKAlgorithm(ARS222(), NewtonsMethod(; max_iters = 1)),
-        CTS.IMEXARKAlgorithm(ARS343(), NewtonsMethod(; max_iters = 1)),
+        CTS.IMEXAlgorithm(ARS111(), NewtonsMethod(; max_iters = 1)),
+        CTS.IMEXAlgorithm(ARS121(), NewtonsMethod(; max_iters = 1)),
+        CTS.IMEXAlgorithm(ARS122(), NewtonsMethod(; max_iters = 1)),
+        CTS.IMEXAlgorithm(ARS232(), NewtonsMethod(; max_iters = 1)),
+        CTS.IMEXAlgorithm(ARS222(), NewtonsMethod(; max_iters = 1)),
+        CTS.IMEXAlgorithm(ARS343(), NewtonsMethod(; max_iters = 1)),
     )
     reference_sol_norm = [
         860.2745315698107

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -1,10 +1,8 @@
 import ClimaTimeSteppers as CTS
 using Test
 
-problem(test_case, tab::CTS.AbstractIMEXARKTableau) = test_case.split_prob
-problem(test_case, tab::CTS.AbstractIMEXSSPARKTableau) = test_case.split_prob
+problem(test_case, tab::CTS.IMEXAlgorithmName) = test_case.split_prob
 problem(test_case, tab) = test_case.prob
 
-algorithm(tab::CTS.AbstractIMEXARKTableau) = CTS.IMEXARKAlgorithm(tab, NewtonsMethod(; max_iters = 2))
-algorithm(tab::CTS.AbstractIMEXSSPARKTableau) = CTS.IMEXSSPRKAlgorithm(tab, NewtonsMethod(; max_iters = 2))
+algorithm(tab::CTS.IMEXAlgorithmName) = CTS.IMEXAlgorithm(tab, NewtonsMethod(; max_iters = 2))
 algorithm(tab) = tab


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
This PR renames several data structures in preparation for the "mode" changes outlined in #151.

## Content
- `AbstractTableau` -> `AbstractAlgorithmName`
- `AbstractARKTableau` -> `ARKAlgorithmName`
- `AbstractSSPRKTableau` -> `SSPRKAlgorithmName`
- `tabname` -> `algorithm_name`
- `IMEXARKTableau` -> `IMEXTableaus`
- `tableau` -> `IMEXTableaus`
- `make_IMKGTableau` -> `IMKGTableaus`
- `imex_ark_tableaus.jl` -> `imex_tableaus.jl`
- Rearrange a few lines in the docs
- Make the inner `IMEXARKAlgorithm` constructor into an outer constructor (will be needed later when combining this with the `IMEXSSPRKAlgorithm` constructor)

<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [x] I have read and checked the items on the review checklist.
