### PR TITLE
add RK4 explicit tableau

### DIFF
--- a/docs/refs.bib
+++ b/docs/refs.bib
@@ -41,6 +41,15 @@
    year = {1900},
 }
 
+@book{SM2003,
+  title = {An Introduction to Numerical Analysis},
+  author = {S{\"u}li, Endre and Mayers, David},
+  year = {2003},
+  publisher = {Cambridge University Press},
+  pages = {352},
+  isbn = {0521007941}
+}
+
 @article{Rals1962,
   title={Runge-Kutta methods with minimum error bounds},
   author={Ralston, Anthony},

--- a/docs/src/api/ode_solvers.md
+++ b/docs/src/api/ode_solvers.md
@@ -58,6 +58,7 @@ ARK548L2SA2
 ```@docs
 SSP22Heuns
 SSP33ShuOsher
+RK4
 ```
 
 ## Old LSRK Interface

--- a/docs/src/plotting_utils.jl
+++ b/docs/src/plotting_utils.jl
@@ -57,6 +57,7 @@ imex_convergence_orders(::ARK437L2SA1) = (4, 4, 4)
 imex_convergence_orders(::ARK548L2SA2) = (5, 5, 5)
 imex_convergence_orders(::SSP22Heuns) = (2, 2, 2)
 imex_convergence_orders(::SSP33ShuOsher) = (3, 3, 3)
+imex_convergence_orders(::RK4) = (4, 4, 4)
 
 # Compute a confidence interval for the convergence order, returning the
 # estimated convergence order and its uncertainty.

--- a/src/solvers/explicit_tableaus.jl
+++ b/src/solvers/explicit_tableaus.jl
@@ -1,5 +1,5 @@
 export ExplicitTableau, ExplicitAlgorithm
-export SSP22Heuns, SSP33ShuOsher
+export SSP22Heuns, SSP33ShuOsher, RK4
 
 abstract type ERKAlgorithmName <: AbstractAlgorithmName end
 
@@ -76,4 +76,20 @@ function ExplicitTableau(::SSP33ShuOsher)
         1 0 0
         1/4 1/4 0
     ]), b = @SArray([1 / 6, 1 / 6, 2 / 3]))
+end
+
+"""
+    RK4
+
+The RK4 algorithm from [SM2003](@cite), a Runge-Kutta method with
+4 stages and 4th order accuracy.
+"""
+struct RK4 <: ERKAlgorithmName end
+function ExplicitTableau(::RK4)
+    return ExplicitTableau(; a = @SArray([
+        0 0 0 0
+        1/2 0 0 0
+        0 1/2 0 0
+        0 0 1 0
+    ]), b = @SArray([1 / 6, 1 / 3, 1 / 3, 1 / 6]))
 end


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
ClimaLSM.jl wants to use the RK4 explicit algorithm, so we should implement it here.

Closes #183

## Content
- [x] Add RK4 to explicit tableaus
- [x] Add citation
- [x] Add expected convergence order

<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [x] I have read and checked the items on the review checklist.
