### PR TITLE
Temporarily disable buildkite

### DIFF
--- a/bors.toml
+++ b/bors.toml
@@ -2,7 +2,6 @@ status = [
   "test-os (1.8, ubuntu-latest)",
   "test-os (1.8, windows-latest)",
   "test-os (1.8, macos-latest)",
-  "buildkite/climatimesteppers-ci",
   "format",
   "docbuild"
 ]


### PR DESCRIPTION
This PR temporarily disables requiring a pass check from buildkite. We can add this back in next week when caltech central is back online.