### PR TITLE
Simplify signal handlers

### DIFF
--- a/src/nl_solvers/newtons_method.jl
+++ b/src/nl_solvers/newtons_method.jl
@@ -557,7 +557,6 @@ function allocate_cache(alg::NewtonsMethod, x_prototype, j_prototype = nothing)
     (; update_j, krylov_method, convergence_checker) = alg
     @assert !(isnothing(j_prototype) && (isnothing(krylov_method) || isnothing(krylov_method.jacobian_free_jvp)))
     return (;
-        update_j_cache = allocate_cache(update_j, eltype(x_prototype)),
         krylov_method_cache = isnothing(krylov_method) ? nothing : allocate_cache(krylov_method, x_prototype),
         convergence_checker_cache = isnothing(convergence_checker) ? nothing :
                                     allocate_cache(convergence_checker, x_prototype),
@@ -569,9 +568,9 @@ end
 
 function solve_newton!(alg::NewtonsMethod, cache, x, f!, j! = nothing)
     (; max_iters, update_j, krylov_method, convergence_checker, verbose) = alg
-    (; update_j_cache, krylov_method_cache, convergence_checker_cache) = cache
+    (; krylov_method_cache, convergence_checker_cache) = cache
     (; Δx, f, j) = cache
-    if (!isnothing(j)) && needs_update!(update_j, update_j_cache, NewNewtonSolve())
+    if (!isnothing(j)) && needs_update!(update_j, NewNewtonSolve())
         j!(j, x)
     end
     for n in 0:max_iters
@@ -583,7 +582,7 @@ function solve_newton!(alg::NewtonsMethod, cache, x, f!, j! = nothing)
         end
 
         # Compute Δx[n].
-        if (!isnothing(j)) && needs_update!(update_j, update_j_cache, NewNewtonIteration())
+        if (!isnothing(j)) && needs_update!(update_j, NewNewtonIteration())
             j!(j, x)
         end
         f!(f, x)

--- a/src/solvers/imex_ark.jl
+++ b/src/solvers/imex_ark.jl
@@ -57,9 +57,8 @@ function step_u!(integrator, cache::IMEXARKCache)
     if !isnothing(T_imp!) && !isnothing(newtons_method)
         NVTX.@range "update!" color = colorant"yellow" begin
             (; update_j) = newtons_method
-            (; update_j_cache) = newtons_method_cache
             jacobian = newtons_method_cache.j
-            if (!isnothing(jacobian)) && needs_update!(update_j, update_j_cache, NewTimeStep(t))
+            if (!isnothing(jacobian)) && needs_update!(update_j, NewTimeStep(t))
                 if γ isa Nothing
                     sdirk_error(name)
                 else

--- a/src/solvers/imex_ssprk.jl
+++ b/src/solvers/imex_ssprk.jl
@@ -63,9 +63,8 @@ function step_u!(integrator, cache::IMEXSSPRKCache)
 
     if !isnothing(T_imp!) && !isnothing(newtons_method)
         (; update_j) = newtons_method
-        (; update_j_cache) = newtons_method_cache
         jacobian = newtons_method_cache.j
-        if (!isnothing(jacobian)) && needs_update!(update_j, update_j_cache, NewTimeStep(t))
+        if (!isnothing(jacobian)) && needs_update!(update_j, NewTimeStep(t))
             if γ isa Nothing
                 sdirk_error(name)
             else

--- a/src/utilities/update_signal_handler.jl
+++ b/src/utilities/update_signal_handler.jl
@@ -4,24 +4,21 @@ export UpdateSignalHandler, UpdateEvery, UpdateEveryN, UpdateEveryDt
 """
     UpdateSignal
 
-A signal that gets passed to an `UpdateSignalHandler` whenever a certain
-operation is performed.
+A signal that gets passed to an `UpdateSignalHandler`
+whenever a certain operation is performed.
 """
 abstract type UpdateSignal end
 
 """
     UpdateSignalHandler
 
-A boolean indicating if updates a value upon receiving an appropriate
-`UpdateSignal`. This is done by calling
-`needs_update!(::UpdateSignalHandler, cache, ::UpdateSignal)`.
-
-The `cache` can be obtained with `allocate_cache(::UpdateSignalHandler, FT)`,
-where `FT` is the floating-point type of the integrator.
+A boolean indicating if updates a value upon receiving
+an appropriate `UpdateSignal`. This is done by calling
+`needs_update!(::UpdateSignalHandler, ::UpdateSignal)`.
 """
 abstract type UpdateSignalHandler end
 
-needs_update!(::UpdateSignalHandler, cache, ::UpdateSignal) = false
+needs_update!(::UpdateSignalHandler, ::UpdateSignal) = false
 
 """
     NewTimeStep(t)
@@ -56,9 +53,7 @@ An `UpdateSignalHandler` that performs the update whenever it is `needs_update!`
 struct UpdateEvery{U <: UpdateSignal} <: UpdateSignalHandler end
 UpdateEvery(::Type{U}) where {U} = UpdateEvery{U}()
 
-allocate_cache(::UpdateEvery, _) = nothing
-
-needs_update!(alg::UpdateEvery{U}, cache, ::U) where {U <: UpdateSignal} = true
+needs_update!(alg::UpdateEvery{U}, ::U) where {U <: UpdateSignal} = true
 
 """
     UpdateEveryN(n, update_signal_type, reset_signal_type = Nothing)
@@ -69,16 +64,14 @@ specified, then the counter (which gets incremented from 0 to `n` and then gets
 reset to 0 when it is time to perform another update) is reset to 0 whenever the
 signal handler is `needs_update!` with an `UpdateSignal` of type `reset_signal_type`.
 """
-struct UpdateEveryN{U <: UpdateSignal, R <: Union{Nothing, UpdateSignal}} <: UpdateSignalHandler
+struct UpdateEveryN{U <: UpdateSignal, C, R <: Union{Nothing, UpdateSignal}} <: UpdateSignalHandler
     n::Int
+    counter::C
 end
-UpdateEveryN(n, ::Type{U}, ::Type{R} = Nothing) where {U, R} = UpdateEveryN{U, R}(n)
+UpdateEveryN(n, ::Type{U}, ::Type{R} = Nothing) where {U, R} = UpdateEveryN{U, typeof(Ref(0)), R}(n, Ref(0))
 
-allocate_cache(::UpdateEveryN, _) = (; counter = Ref(0))
-
-function needs_update!(alg::UpdateEveryN{U}, cache, ::U) where {U <: UpdateSignal}
-    (; n) = alg
-    (; counter) = cache
+function needs_update!(alg::UpdateEveryN{U}, ::U) where {U <: UpdateSignal}
+    (; n, counter) = alg
     result = counter[] == 0
     counter[] += 1
     if counter[] == n
@@ -86,14 +79,14 @@ function needs_update!(alg::UpdateEveryN{U}, cache, ::U) where {U <: UpdateSigna
     end
     return result
 end
-function needs_update!(alg::UpdateEveryN{U, R}, cache, ::R) where {U, R <: UpdateSignal}
-    (; counter) = cache
+function needs_update!(alg::UpdateEveryN{U, R}, ::R) where {U, R <: UpdateSignal}
+    (; counter) = alg
     counter[] = 0
     return false
 end
 
 # Account for method ambiguitiy:
-needs_update!(::UpdateEveryN{U, U}, cache, ::U) where {U <: UpdateSignal} =
+needs_update!(::UpdateEveryN{U, U}, ::U) where {U <: UpdateSignal} =
     error("Reset and update signal types cannot be the same.")
 
 """
@@ -103,16 +96,15 @@ An `UpdateSignalHandler` that performs the update whenever it is `needs_update!`
 `UpdateSignal` of type `NewTimeStep` and the difference between the current time
 and the previous update time is no less than `dt`.
 """
-struct UpdateEveryDt{T} <: UpdateSignalHandler
+struct UpdateEveryDt{T, BR, FTR} <: UpdateSignalHandler
     dt::T
+    is_first_t::BR
+    prev_update_t::FTR
 end
+UpdateEveryDt(dt::Type{FT}) where {FT} = UpdateEveryDt(dt, Ref(true), Ref{FT}())
 
-# TODO: This assumes that typeof(t) == FT, which might not always be correct.
-allocate_cache(alg::UpdateEveryDt, ::Type{FT}) where {FT} = (; is_first_t = Ref(true), prev_update_t = Ref{FT}())
-
-function needs_update!(alg::UpdateEveryDt, cache, signal::NewTimeStep)
-    (; dt) = alg
-    (; is_first_t, prev_update_t) = cache
+function needs_update!(alg::UpdateEveryDt, signal::NewTimeStep)
+    (; dt, is_first_t, prev_update_t) = alg
     (; t) = signal
     result = false
     if is_first_t[] || abs(t - prev_update_t[]) >= dt


### PR DESCRIPTION
This PR unifies the signal handlers and their caches-- I think having them split just complicated the `needs_update!` interface.