### PR TITLE
Correct patch version

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ClimaTimeSteppers"
 uuid = "595c0a79-7f3d-439a-bc5a-b232dc3bde79"
 authors = ["Climate Modeling Alliance"]
-version = "0.7.10"
+version = "0.7.8"
 
 [deps]
 CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"


### PR DESCRIPTION
We accidentally skipped version 0.8 (so 0.9 was never registered as I had intended).