### PR TITLE
Improve names, reorder newton solver

### DIFF
--- a/src/utilities/convergence_checker.jl
+++ b/src/utilities/convergence_checker.jl
@@ -12,7 +12,7 @@ using LinearAlgebra: norm
 
 Checks whether a sequence `val[0], val[1], val[2], ...` has converged to some
 limit `L`, given the errors `err[iter] = val[iter] .- L`. This is done by
-calling `check_convergence!(::ConvergenceChecker, cache, val, err, iter)`, where
+calling `is_converged!(::ConvergenceChecker, cache, val, err, iter)`, where
 `val = val[iter]` and `err = err[iter]`. If the value of `L` is not known, `err`
 can be an approximation of `err[iter]`. The `cache` for a `ConvergenceChecker`
 can be obtained with `allocate_cache(::ConvergenceChecker, val_prototype)`,
@@ -68,7 +68,9 @@ function has_component_converged(alg, cache, val, err, iter)
     return all(component_bools)
 end
 
-function check_convergence!(alg::ConvergenceChecker, cache, val, err, iter)
+is_converged!(alg::Nothing, cache, val, err, iter) = false
+
+function is_converged!(alg::ConvergenceChecker, cache, val, err, iter)
     (; norm_condition, component_condition, condition_combiner, norm) = alg
     (; norm_cache, component_cache) = cache
     if isnothing(norm_condition)

--- a/test/test_convergence_checker.jl
+++ b/test/test_convergence_checker.jl
@@ -17,9 +17,9 @@ import ClimaTimeSteppers as CTS
         cache = CTS.allocate_cache(checker, val_func(0))
         for (err_func, last_iter) in ((err_func1, last_iter1), (err_func2, last_iter2))
             for iter in 0:(last_iter - 1)
-                CTS.check_convergence!(checker, cache, val_func(iter), err_func(iter), iter) && return false
+                CTS.is_converged!(checker, cache, val_func(iter), err_func(iter), iter) && return false
             end
-            CTS.check_convergence!(checker, cache, val_func(last_iter), err_func(last_iter), last_iter) || return false
+            CTS.is_converged!(checker, cache, val_func(last_iter), err_func(last_iter), last_iter) || return false
         end
         return true
     end


### PR DESCRIPTION
This PR reorders the newton solver, to ensure that we always end in post implicit callback.

On the main branch, it's possible that `check_convergence!` returns true on `n=0`, resulting in a break before the post implicit callback is called.

I've also renamed `check_convergence!` to `is_converged!`