### PR TITLE
Add `post_explicit!` call to end of step, rm nvtx range macros

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ClimaTimeSteppers"
 uuid = "595c0a79-7f3d-439a-bc5a-b232dc3bde79"
 authors = ["Climate Modeling Alliance"]
-version = "0.7.11"
+version = "0.7.12"
 
 [deps]
 CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"

--- a/src/solvers/imex_ssprk.jl
+++ b/src/solvers/imex_ssprk.jl
@@ -185,6 +185,7 @@ function step_u!(integrator, cache::IMEXSSPRKCache, f, name)
     end
 
     dss!(u, p, t_final)
+    post_explicit!(u, p, t_final)
 
     return u
 end


### PR DESCRIPTION
This PR
 - Adds `post_explicit!` calls to end of step
 - Removes nvtx range macros, since they seem to be blowing up memory requirements (example build here: https://buildkite.com/clima/climaatmos-ci/builds/13552)