### PR TITLE
Remove extraneous `dss!` and `post_explicit!` calls

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ClimaTimeSteppers"
 uuid = "595c0a79-7f3d-439a-bc5a-b232dc3bde79"
 authors = ["Climate Modeling Alliance"]
-version = "0.7.13"
+version = "0.7.14"
 
 [deps]
 CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"

--- a/src/solvers/imex_ark.jl
+++ b/src/solvers/imex_ark.jl
@@ -98,12 +98,12 @@ function step_u!(integrator, cache::IMEXARKCache)
 
         i ≠ 1 && dss!(U, p, t_exp)
 
-        if !(!isnothing(T_imp!) && !iszero(a_imp[i, i])) # Implicit solve
-            post_explicit!(U, p, t_imp)
-        else
+        if !(!isnothing(T_imp!) && !iszero(a_imp[i, i]))
+            i ≠ 1 && post_explicit!(U, p, t_imp)
+        else # Implicit solve
             @assert !isnothing(newtons_method)
             @. temp = U
-            post_explicit!(U, p, t_imp)
+            i ≠ 1 && post_explicit!(U, p, t_imp)
             # TODO: can/should we remove these closures?
             implicit_equation_residual! = (residual, Ui) -> begin
                 T_imp!(residual, Ui, p, t_imp)

--- a/src/solvers/imex_ark.jl
+++ b/src/solvers/imex_ark.jl
@@ -96,7 +96,7 @@ function step_u!(integrator, cache::IMEXARKCache)
             end
         end
 
-        dss!(U, p, t_exp)
+        i ≠ 1 && dss!(U, p, t_exp)
 
         if !(!isnothing(T_imp!) && !iszero(a_imp[i, i])) # Implicit solve
             post_explicit!(U, p, t_imp)

--- a/src/solvers/imex_ssprk.jl
+++ b/src/solvers/imex_ssprk.jl
@@ -104,9 +104,9 @@ function step_u!(integrator, cache::IMEXSSPRKCache)
             end
         end
 
-        if !(!isnothing(T_imp!) && !iszero(a_imp[i, i])) # Implicit solve
-            post_explicit!(U, p, t_imp)
-        else
+        if !(!isnothing(T_imp!) && !iszero(a_imp[i, i]))
+            i ≠ 1 && post_explicit!(U, p, t_imp)
+        else # Implicit solve
             @assert !isnothing(newtons_method)
             @. temp = U
             post_explicit!(U, p, t_imp)

--- a/src/solvers/imex_ssprk.jl
+++ b/src/solvers/imex_ssprk.jl
@@ -94,7 +94,7 @@ function step_u!(integrator, cache::IMEXSSPRKCache)
             @. U_exp = (1 - β[i - 1]) * u + β[i - 1] * U_exp
         end
 
-        dss!(U_exp, p, t_exp)
+        i ≠ 1 && dss!(U_exp, p, t_exp)
 
         @. U = U_exp
         if !isnothing(T_imp!) # Update based on implicit tendencies from previous stages


### PR DESCRIPTION
This PR removes extraneous dss calls. Tested out in https://buildkite.com/clima/climaatmos-ci/builds/13595, results look like they've only changed by machine precision.