### PR TITLE
Eliminate a call to `lim!`

### DIFF
--- a/src/solvers/imex_ark.jl
+++ b/src/solvers/imex_ark.jl
@@ -79,7 +79,7 @@ function step_u!(integrator, cache::IMEXARKCache)
                 iszero(a_exp[i, j]) && continue
                 @. U += dt * a_exp[i, j] * T_lim[j]
             end
-            lim!(U, p, t_exp, u)
+            i ≠ 1 && lim!(U, p, t_exp, u)
         end
 
         if !isnothing(T_exp!) # Update based on explicit tendencies from previous stages


### PR DESCRIPTION
While working on the limiters, it occurred to me that when we have limiters with `i = 1` in the ARK method:

```julia
@. U = u

for j in 1:(i - 1)
    iszero(a_exp[i, j]) && continue
    @. U += dt * a_exp[i, j] * T_lim[j]
end
lim!(U, p, t_exp, u)
```
we have 
```julia
@. U = u
lim!(U, p, t_exp, u)
```
and I think that, since `u` is just a copy of `U`, `lim!(U, p, t_exp, u)` will do nothing (based on the existing implementation with automatically computing bounds). Therefore, we can eliminate this call (for `i = 1`).

Doing this optimization of course assumes that `lim!(U, p, t_exp, U)` does nothing, and this will be wrong if later we decide that it should do something. However, it's not clear to me that we will need to/want to change it.