### PR TITLE
Fix and rename has_DataType_or_UnionAll

### DIFF
--- a/test/integrator.jl
+++ b/test/integrator.jl
@@ -141,7 +141,7 @@ end
             ((; saveat = save_dt, tstops = all_times), (; erase_sol = false), all_times),
         )
             integrator = init(deepcopy(prob), alg; dt, init_kwargs...)
-            @test !@has_DataType_or_UnionAll(integrator)
+            @test !@any_reltype(integrator, (UnionAll, DataType))
             solve!(integrator)
             reinit!(integrator, u0′; t0 = t0′, tf = tf′, reinit_kwargs...)
             sol = solve!(integrator)

--- a/test/integrator_utils.jl
+++ b/test/integrator_utils.jl
@@ -1,20 +1,24 @@
-function has_DataType_or_UnionAll(obj, name, pc = ())
+"""
+    @any_reltype(::Any, t::Tuple, warn=true)
+
+Returns a Bool (and prints warnings) if the given
+data structure has an instance of any types in `t`.
+"""
+function any_reltype(found, obj, name, ets, pc = (); warn = true)
     for pn in propertynames(obj)
         prop = getproperty(obj, pn)
         pc_full = (pc..., ".", pn)
         pc_string = name * string(join(pc_full))
-        if prop isa DataType
-            @warn "$pc_string::$(typeof(prop)) is a DataType"
-            return true
-        elseif prop isa UnionAll
-            @warn "$pc_string::$(typeof(prop)) is a UnionAll"
-            return true
-        else
-            has_DataType_or_UnionAll(prop, name, pc_full)
+        for et in ets
+            if prop isa et
+                warn && @warn "$pc_string::$(typeof(prop)) is a DataType"
+                found = true
+            end
         end
+        found = found || any_reltype(found, prop, name, ets, pc_full; warn)
     end
-    return false
+    return found
 end
-macro has_DataType_or_UnionAll(obj)
-    return :(has_DataType_or_UnionAll($(esc(obj)), $(string(obj))))
+macro any_reltype(obj, ets, warn = true)
+    return :(any_reltype(false, $(esc(obj)), $(string(obj)), $(esc(ets)); warn = $(esc(warn))))
 end


### PR DESCRIPTION
This PR fixes and renames `has_DataType_or_UnionAll`.