### PR TITLE
Add nvtx range to callbacks

### DIFF
--- a/src/integrators.jl
+++ b/src/integrators.jl
@@ -217,9 +217,11 @@ function __step!(integrator)
 
     # apply callbacks
     discrete_callbacks = integrator.callback.discrete_callbacks
-    for callback in discrete_callbacks
+    for (ncb, callback) in enumerate(discrete_callbacks)
         if callback.condition(integrator.u, integrator.t, integrator)
-            callback.affect!(integrator)
+            NVTX.@range "Callback $ncb of $(length(discrete_callbacks))" color = colorant"yellow" begin
+                callback.affect!(integrator)
+            end
         end
     end
 


### PR DESCRIPTION
This PR adds NVTX ranges to the callbacks, so that we have callback-by-callback granularity from the timestepper (the names will just be numbered at this level), but we can also add annotations to the Atmos callbacks, so that we can appropriately name them.