### PR TITLE
Add support for fused incrementing

### DIFF
--- a/src/ClimaTimeSteppers.jl
+++ b/src/ClimaTimeSteppers.jl
@@ -59,6 +59,8 @@ array_device(x) = CUDADevice() # assume CUDA
 
 import DiffEqBase, SciMLBase, LinearAlgebra, DiffEqCallbacks, Krylov
 
+include(joinpath("utilities", "sparse_coeffs.jl"))
+include(joinpath("utilities", "fused_increment.jl"))
 include("sparse_containers.jl")
 include("functions.jl")
 
@@ -112,6 +114,8 @@ n_stages_ntuple(::Type{<:NTuple{Nstages}}) where {Nstages} = Nstages
 n_stages_ntuple(::Type{<:SVector{Nstages}}) where {Nstages} = Nstages
 
 # Include concrete implementations
+const SPCO = SparseCoeffs
+
 include("solvers/imex_tableaus.jl")
 include("solvers/explicit_tableaus.jl")
 include("solvers/imex_ark.jl")

--- a/src/solvers/explicit_tableaus.jl
+++ b/src/solvers/explicit_tableaus.jl
@@ -11,11 +11,12 @@ default value for `b` assumes that the algorithm is FSAL (first same as last),
 and the default value for `c` assumes that it is internally consistent. The
 matrix `a` must be strictly lower triangular.
 """
-struct ExplicitTableau{VS <: StaticArrays.StaticArray, MS <: StaticArrays.StaticArray}
-    a::MS # matrix of size s×s
-    b::VS # vector of length s
-    c::VS # vector of length s
+struct ExplicitTableau{A <: SPCO, B <: SPCO, C <: SPCO}
+    a::A # matrix of size s×s
+    b::B # vector of length s
+    c::C # vector of length s
 end
+ExplicitTableau(args...) = ExplicitTableau(map(x -> SparseCoeffs(x), args)...)
 function ExplicitTableau(; a, b = a[end, :], c = vec(sum(a; dims = 2)))
     @assert all(iszero, UpperTriangular(a))
     b, c = promote(b, c) # TODO: add generic promote_eltype

--- a/src/solvers/imex_ssprk.jl
+++ b/src/solvers/imex_ssprk.jl
@@ -26,10 +26,10 @@ function init_cache(prob::DiffEqBase.AbstractODEProblem, alg::IMEXAlgorithm{SSP}
     U_lim = similar(u0)
     T_imp = SparseContainer(map(i -> similar(u0), collect(1:length(inds_T_imp))), inds_T_imp)
     temp = similar(u0)
-    â_exp = vcat(a_exp, b_exp')
-    β = diag(â_exp, -1)
+    â_exp = SparseCoeffs(vcat(a_exp.coeffs, b_exp.coeffs'))
+    β = SparseCoeffs(diag(â_exp, -1))
     for i in 1:length(β)
-        if â_exp[(i + 1):end, i] != cumprod(β[i:end])
+        if â_exp.coeffs[(i + 1):end, i] != cumprod(β.coeffs[i:end])
             error("The SSP IMEXAlgorithm currently only supports an \
                    IMEXTableau that specifies a \"low-storage\" IMEX SSPRK \
                    algorithm, where the canonical Shu-Osher representation of \

--- a/src/solvers/imex_tableaus.jl
+++ b/src/solvers/imex_tableaus.jl
@@ -19,14 +19,16 @@ default values for `c_exp` and `c_imp` assume that it is internally consistent.
 The explicit tableau must be strictly lower triangular, and the implicit tableau
 must be lower triangular (only DIRK algorithms are currently supported).
 """
-struct IMEXTableau{VS <: StaticArrays.StaticArray, MS <: StaticArrays.StaticArray}
-    a_exp::MS # matrix of size s×s
-    b_exp::VS # vector of length s
-    c_exp::VS # vector of length s
-    a_imp::MS # matrix of size s×s
-    b_imp::VS # vector of length s
-    c_imp::VS # vector of length s
+struct IMEXTableau{AE <: SPCO, BE <: SPCO, CE <: SPCO, AI <: SPCO, BI <: SPCO, CI <: SPCO}
+    a_exp::AE # matrix of size s×s
+    b_exp::BE # vector of length s
+    c_exp::CE # vector of length s
+    a_imp::AI # matrix of size s×s
+    b_imp::BI # vector of length s
+    c_imp::CI # vector of length s
 end
+IMEXTableau(args...) = IMEXTableau(map(x -> SparseCoeffs(x), args)...)
+
 function IMEXTableau(;
     a_exp,
     b_exp = a_exp[end, :],

--- a/src/utilities/fused_increment.jl
+++ b/src/utilities/fused_increment.jl
@@ -1,0 +1,107 @@
+"""
+    fused_increment(u, dt, sc::SparseCoeffs{S}, tend, ::Val{i}) where {i, S}
+
+Returns a broadcasted object in the form
+
+    `u + ∑ⱼ dt scⱼ  tendⱼ for j in 1:i`
+    or
+    `u + ∑ⱼ dt scᵢⱼ tendⱼ for j in 1:(i-1)`
+
+depending on the dimensions of the coefficients in `sc`. The
+broadcasted object drops zero coefficients from the expression
+at compile-time using the mask `mask` (made from `SparseCoeffs(coeffs)`).
+
+Returns `u` when `i ≤ 1` or if the mask is all true (all coefficients are zero).
+
+
+# Example loops that this is fusing:
+
+For 2D coefficients case
+```julia
+for j in 1:(i - 1)
+    iszero(a_imp[i, j]) && continue
+    @. U += dt * a_imp[i, j] * T_imp[j]
+end
+
+For 1D coefficients case
+```julia
+for j in 1:s
+    iszero(b_exp[j]) && continue
+    @. temp += dt * b_exp[j] * T_lim[j]
+end
+```
+"""
+function fused_increment end
+
+@inline fused_increment(u, dt, sc, tend, v) = fused_increment(u, dt, sc, tend, v, get_S(sc))
+
+# ij case (S::NTuple{2})
+@generated function fused_increment(u, dt, sc::T, tend, ::Val{i}, ::NTuple{2}) where {i, S, T <: SparseCoeffs{S}}
+    i ≤ 1 && return :(u)
+    terms = []
+    for j in 1:(i - 1)
+        zero_coeff(T, i, j) && continue
+        push!(terms, :(Base.Broadcast.broadcasted(*, dt * sc[$i, $j], tend[$j])))
+    end
+    isempty(terms) && return :(u)
+    expr = Meta.parse(join(terms, ","))
+    if length(terms) == 1
+        return :(Base.Broadcast.broadcasted(+, u, $expr))
+    else
+        return :(Base.Broadcast.broadcasted(+, u, $expr...))
+    end
+end
+
+# j case (S::NTuple{1})
+@generated function fused_increment(u, dt, sc::T, tend, ::Val{s}, ::NTuple{1}) where {s, S, T <: SparseCoeffs{S}}
+    all(j -> zero_coeff(T, j), 1:s) && return :(u)
+    terms = []
+    for j in 1:s
+        zero_coeff(T, j) && continue
+        push!(terms, :(Base.Broadcast.broadcasted(*, dt * sc[$j], tend[$j])))
+    end
+    expr = Meta.parse(join(terms, ","))
+    if length(terms) == 1
+        return :(Base.Broadcast.broadcasted(+, u, $expr))
+    else
+        return :(Base.Broadcast.broadcasted(+, u, $expr...))
+    end
+end
+
+"""
+    fused_increment!(u, dt, sc, tend, v)
+
+Calls [`fused_increment`](@ref) and materializes
+a broadcast expression in the form:
+
+    `@. u += ∑ⱼ dt scⱼ tendⱼ`
+
+In the edge case (coeffs are zero, `j` range is empty),
+this lowers to `nothing` (no-op)
+"""
+function fused_increment!(u, dt, sc, tend, v)
+    bc = fused_increment(u, dt, sc, tend, v)
+    if bc isa Base.Broadcast.Broadcasted # Only material if not trivial assignment
+        Base.Broadcast.materialize!(u, bc)
+    end
+    nothing
+end
+
+"""
+    assign_fused_increment!(U, u, dt, sc, tend, v)
+
+Calls [`fused_increment`](@ref) and materializes
+a broadcast expression in the form:
+
+    `@. u += ∑ⱼ dt scⱼ tendⱼ`
+
+In the edge case (coeffs are zero, `j` range is empty),
+this lowers to
+
+    `@. U = u`
+"""
+function assign_fused_increment!(U, u, dt, sc, tend, v)
+    bc = fused_increment(u, dt, sc, tend, v)
+    Base.Broadcast.materialize!(U, bc)
+    return nothing
+end

--- a/src/utilities/sparse_coeffs.jl
+++ b/src/utilities/sparse_coeffs.jl
@@ -1,0 +1,31 @@
+"""
+    SparseCoeffs(coefficients)
+
+A mask for coefficients. Supports `getindex(::SparseCoeffs, ijk...)`
+that forwards to coefficients, and `getindex(::Type{SparseCoeffs}, ijk...)`
+that forwards (at compile time) to the mask, which behaves as a
+BitArray of the coefficients.
+"""
+struct SparseCoeffs{S, m, C}
+    coeffs::C
+    function SparseCoeffs(coeffs::C) where {C}
+        m = BitArray(iszero.(coeffs))
+        return new{size(m), Tuple(m), C}(coeffs)
+    end
+end
+
+# Forward array behavior:
+Base.@propagate_inbounds Base.getindex(sc::SparseCoeffs, inds...) = @inbounds sc.coeffs[inds...]
+Base.length(sc::SparseCoeffs) = length(sc.coeffs)
+import LinearAlgebra
+LinearAlgebra.diag(sc::SparseCoeffs, args...) = LinearAlgebra.diag(sc.coeffs, args...)
+LinearAlgebra.adjoint(sc::SparseCoeffs) = LinearAlgebra.adjoint(sc.coeffs)
+
+get_S(::SparseCoeffs{S}) where {S} = S
+
+# Special behavior of SparseCoeffs:
+Base.@propagate_inbounds zero_coeff(::Type{SparseCoeffs{S, m, C}}, i::Int, j::Int) where {S, m, C} =
+    @inbounds m[i + S[1] * (j - 1)]
+Base.@propagate_inbounds zero_coeff(::Type{SparseCoeffs{S, m, C}}, j::Int) where {S, m, C} = @inbounds m[j]
+
+Base.convert(::Type{T}, x::SArray) where {T <: SparseCoeffs} = SparseCoeffs(x)

--- a/test/fused_increment.jl
+++ b/test/fused_increment.jl
@@ -1,0 +1,157 @@
+using Test
+import Base.Broadcast: broadcasted, materialize
+using StaticArrays
+using ClimaTimeSteppers: SparseCoeffs, fused_increment, fused_increment!, assign_fused_increment!, zero_coeff
+using Random
+
+mat(args...) = materialize(args...)
+function dummy_coeffs(S)
+    Random.seed!(1234)
+    coeffs = rand(S...)
+    for I in eachindex(coeffs)
+        rand() < 0.5 && continue
+        coeffs[I] = 0
+    end
+    return coeffs
+end
+
+function dummy_coeffs_example(S)
+    Random.seed!(1234)
+    coeffs = rand(S...)
+    coeffs[1] = 0
+    coeffs[5] = 0
+    coeffs[6] = 0
+    coeffs[9] = 0
+    coeffs[10] = 0
+    coeffs[11] = 0
+    coeffs[13] = 0
+    coeffs[14] = 0
+    coeffs[15] = 0
+    coeffs[16] = 0
+    return SArray{Tuple{S...}}(coeffs)
+end
+
+@testset "Test indices" begin
+    S = (3, 3)
+    coeffs = dummy_coeffs(S)
+    mask = BitArray(iszero.(coeffs))
+    TMC = typeof(SparseCoeffs(coeffs))
+    for i in 1:S[1], j in 1:S[2]
+        @test zero_coeff(TMC, i, j) == mask[i, j]
+    end
+    S = (3,)
+    coeffs = dummy_coeffs(S)
+    mask = BitArray(iszero.(coeffs))
+    TMC = typeof(SparseCoeffs(coeffs))
+    for i in 1:S[1]
+        @test zero_coeff(TMC, i) == mask[i]
+    end
+end
+
+import Random
+@testset "increment 2D" begin
+    FT = Float64
+    U = FT[1, 2, 3]
+    u = FT[1, 2, 3]
+    tend = ntuple(i -> u .* i, 3)
+    coeffs = dummy_coeffs((3, 3))
+    coeffs .= 0
+    sc = SparseCoeffs(coeffs)
+    dt = 0.5
+    # edge case: zero coeffs
+    @test fused_increment(u, dt, sc, tend, Val(3)) == u
+    @test fused_increment!(u, dt, sc, tend, Val(3)) == nothing
+
+    FT = Float64
+    u = FT[1, 2, 3]
+    tend = ntuple(i -> u .* (i + 3), 3)
+    coeffs = dummy_coeffs((3, 3))
+    coeffs .= 1
+    sc = SparseCoeffs(coeffs)
+    dt = 0.5
+
+    @test fused_increment(u, dt, sc, tend, Val(1)) == u
+
+    bc2 = broadcasted(+, u, broadcasted(*, dt * coeffs[2, 1], tend[1]))
+    @test fused_increment(u, dt, sc, tend, Val(2)) == bc2
+    @test mat(fused_increment(u, dt, sc, tend, Val(2))) == @. u + dt * coeffs[2, 1] * tend[1]
+
+    bc3 = broadcasted(+, u, broadcasted(*, dt * coeffs[3, 1], tend[1]), broadcasted(*, dt * coeffs[3, 2], tend[2]))
+    @test mat(fused_increment(u, dt, sc, tend, Val(3))) == mat(bc3)
+
+    @test materialize(bc2) == @. u + dt * coeffs[2, 1] * tend[1]
+
+    assign_fused_increment!(U, u, dt, sc, tend, Val(2))
+    @test U == @. u + dt * coeffs[2, 1] * tend[1]
+
+    FT = Float64
+    u = FT[1, 2, 3]
+    tend = ntuple(i -> u .* (i + 1), 3)
+    coeffs = dummy_coeffs_example((4, 4))
+    sc = SparseCoeffs(coeffs)
+    dt = 0.5
+
+    bcb = fused_increment(u, dt, sc, tend, Val(4))
+    fused_increment!(u, dt, sc, tend, Val(4))
+end
+
+@testset "increment 1D" begin
+    FT = Float64
+    U = FT[1, 2, 3]
+    u = FT[1, 2, 3]
+    tend = ntuple(i -> u .* i, 3)
+    coeffs = dummy_coeffs((3,))
+    coeffs .= 0
+    sc = SparseCoeffs(coeffs)
+    dt = 0.5
+    # Edge case (zero coeffs)
+    @test fused_increment(u, dt, sc, tend, Val(1)) == u
+    @test fused_increment!(u, dt, sc, tend, Val(1)) == nothing
+
+    FT = Float64
+    u = FT[1, 2, 3]
+    tend = ntuple(i -> u .* i, 3)
+    coeffs = dummy_coeffs((3,))
+    coeffs .= 1
+    sc = SparseCoeffs(coeffs)
+    dt = 0.5
+
+    bc2 = broadcasted(+, u, broadcasted(*, dt * coeffs[1], tend[1]))
+    @test fused_increment(u, dt, sc, tend, Val(1)) == bc2
+
+    bc3 = broadcasted(+, u, broadcasted(*, dt * coeffs[1], tend[1]), broadcasted(*, dt * coeffs[2], tend[2]))
+    @test fused_increment(u, dt, sc, tend, Val(2)) == bc3
+
+    @test Base.Broadcast.materialize(bc2) == @. u + dt * coeffs[1] * tend[1]
+
+    assign_fused_increment!(U, u, dt, sc, tend, Val(1))
+    @test U == @. u + dt * coeffs[1] * tend[1]
+end
+
+@testset "increment 1D mask" begin
+    FT = Float64
+    u = FT[1, 2, 3]
+    tend = ntuple(i -> u .* i, 3)
+    coeffs = dummy_coeffs((3,))
+    coeffs .= 1
+    coeffs[2] = 0
+    sc = SparseCoeffs(coeffs)
+    dt = 0.5
+
+    bc3 = broadcasted(+, u, broadcasted(*, dt * coeffs[1], tend[1]))
+    @test fused_increment(u, dt, sc, tend, Val(2)) == bc3
+end
+
+@testset "increment 2D mask" begin
+    FT = Float64
+    u = FT[1, 2, 3]
+    tend = ntuple(i -> u .* i, 3)
+    coeffs = dummy_coeffs((3, 3))
+    coeffs .= 1
+    coeffs[3, 2] = 0
+    sc = SparseCoeffs(coeffs)
+    dt = 0.5
+
+    bc3 = broadcasted(+, u, broadcasted(*, dt * coeffs[3, 1], tend[1]))
+    @test fused_increment(u, dt, sc, tend, Val(3)) == bc3
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -13,6 +13,9 @@ end
 @safetestset "SparseContainers" begin
     include("sparse_containers.jl")
 end
+@safetestset "Fused incrememnt" begin
+    include("fused_increment.jl")
+end
 @safetestset "Newtons method" begin
     include("test_newtons_method.jl")
 end


### PR DESCRIPTION
This PR adds support for fused incrementing of the state vector for the explicit and imex tableaus. We can easily extend it to the other tableaus, but I've only applied it to these for now.

Fused incrementing is supported by adding a new type: `MaskedCoeffs`, which has a simple definition:
```julia
struct MaskedCoeffs{S, m, C}
    coeffs::C
    function MaskedCoeffs(coeffs::C) where {C}
        m = BitArray(iszero.(coeffs))
        return new{size(m), Tuple(m), C}(coeffs)
    end
end
```

Most behavior of these masks simply forward to the `coeffs`, however, there is a special supported feature: the bit array, which indicates whether the coefficients are zero / skippable or not, are converted to tuples, and retrievable at compile-time:

```julia
# Special behavior of MaskedCoeffs:
Base.@propagate_inbounds Base.getindex(::Type{MaskedCoeffs{S, m, C}}, i::Int, j::Int) where {S, m, C} =
    @inbounds m[i + S[1] * (j - 1)]
Base.@propagate_inbounds Base.getindex(::Type{MaskedCoeffs{S, m, C}}, j::Int) where {S, m, C} = @inbounds m[j]
```

This allows us to easily write a `fused_increment` generated function. The version for 2D coefficients looks like this:

```julia
@inline fused_increment(u, dt, tend, mc, v) = fused_increment(u, dt, tend, mc, v, get_S(mc))

# ij case (S::NTuple{2})
@generated function fused_increment(u, dt, tend, mc::T, ::Val{i}, ::NTuple{2}) where {i, S, T <: MaskedCoeffs{S}}
    i ≤ 1 && return :(u)
    terms = []
    for j in 1:(i - 1)
        T[i, j] && continue
        push!(terms, :(dt * mc[$i, $j] * tend[$j]))
    end
    isempty(terms) && return :(u)
    expr = comma_sep_expr(terms)
    return :(Base.Broadcast.broadcasted(+, u, $expr...))
end
```

One downside of doing this is that the types in the tableaus can no longer be diagonalized. Unless we hard-code implementations based on the algorithm name, I don't think that there is a way to avoid these numbers entering the type space, and grouping them with the coefficients makes book keeping a lot easier. The upside is that only a tuple of Bools enter the type space, rather than the coefficients themselves.