### PR TITLE
Fix Vararg warning

### DIFF
--- a/src/utilities/convergence_condition.jl
+++ b/src/utilities/convergence_condition.jl
@@ -97,7 +97,7 @@ struct MultipleConditions{CC, C} <: ConvergenceCondition
     conditions::C
     function MultipleConditions(
         condition_combiner::Union{typeof(all), typeof(any)},
-        conditions::Vararg{<:ConvergenceCondition},
+        conditions::Vararg{ConvergenceCondition},
     )
         return new{typeof(condition_combiner), typeof(conditions)}(condition_combiner, conditions)
     end


### PR DESCRIPTION
Fixes:

```
┌ ClimaTimeSteppers
│  WARNING: Wrapping `Vararg` directly in UnionAll is deprecated (wrap the tuple instead).
│  You may need to write `f(x::Vararg{T})` rather than `f(x::Vararg{<:T})` or `f(x::Vararg{T}) where T` instead of `f(x::Vararg{T} where T)`.
```