### PR TITLE
Add option to not crop table

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ClimaTimeSteppers"
 uuid = "595c0a79-7f3d-439a-bc5a-b232dc3bde79"
 authors = ["Climate Modeling Alliance"]
-version = "0.7.25"
+version = "0.7.26"
 
 [deps]
 ClimaComms = "3a4d1b5c-c61d-41fd-a00a-5873ba7a1b0d"

--- a/ext/ClimaTimeSteppersBenchmarkToolsExt.jl
+++ b/ext/ClimaTimeSteppersBenchmarkToolsExt.jl
@@ -53,6 +53,7 @@ function CTS.benchmark_step(
     device::ClimaComms.AbstractDevice;
     with_cu_prof = :bprofile,
     trace = false,
+    crop = false,
 )
     (; u, p, t, dt, sol, alg) = integrator
     (; f) = sol.prob
@@ -66,15 +67,15 @@ function CTS.benchmark_step(
         trials₀ = OrderedCollections.OrderedDict()
 
 #! format: off
-		trials₀["Wfact"]          = get_trial(wfact_fun(integrator), (W, u, p, dt, t), "Wfact", device; with_cu_prof, trace);
-		trials₀["ldiv!"]          = get_trial(LA.ldiv!, (X, W, u), "ldiv!", device; with_cu_prof, trace);
-		trials₀["T_imp!"]         = get_trial(implicit_fun(integrator), implicit_args(integrator), "T_imp!", device; with_cu_prof, trace);
-        trials₀["T_exp_T_lim!"]   = get_trial(remaining_fun(integrator), remaining_args(integrator), "T_exp_T_lim!", device; with_cu_prof, trace);
-        trials₀["lim!"]           = get_trial(f.lim!, (Xlim, p, t, u), "lim!", device; with_cu_prof, trace);
-		trials₀["dss!"]           = get_trial(f.dss!, (u, p, t), "dss!", device; with_cu_prof, trace);
-        trials₀["post_explicit!"] = get_trial(f.post_explicit!, (u, p, t), "post_explicit!", device; with_cu_prof, trace);
-        trials₀["post_implicit!"] = get_trial(f.post_implicit!, (u, p, t), "post_implicit!", device; with_cu_prof, trace);
-		trials₀["step!"]          = get_trial(SciMLBase.step!, (integrator, ), "step!", device; with_cu_prof, trace);
+		trials₀["Wfact"]          = get_trial(wfact_fun(integrator), (W, u, p, dt, t), "Wfact", device; with_cu_prof, trace, crop);
+		trials₀["ldiv!"]          = get_trial(LA.ldiv!, (X, W, u), "ldiv!", device; with_cu_prof, trace, crop);
+		trials₀["T_imp!"]         = get_trial(implicit_fun(integrator), implicit_args(integrator), "T_imp!", device; with_cu_prof, trace, crop);
+        trials₀["T_exp_T_lim!"]   = get_trial(remaining_fun(integrator), remaining_args(integrator), "T_exp_T_lim!", device; with_cu_prof, trace, crop);
+        trials₀["lim!"]           = get_trial(f.lim!, (Xlim, p, t, u), "lim!", device; with_cu_prof, trace, crop);
+		trials₀["dss!"]           = get_trial(f.dss!, (u, p, t), "dss!", device; with_cu_prof, trace, crop);
+        trials₀["post_explicit!"] = get_trial(f.post_explicit!, (u, p, t), "post_explicit!", device; with_cu_prof, trace, crop);
+        trials₀["post_implicit!"] = get_trial(f.post_implicit!, (u, p, t), "post_implicit!", device; with_cu_prof, trace, crop);
+		trials₀["step!"]          = get_trial(SciMLBase.step!, (integrator, ), "step!", device; with_cu_prof, trace, crop);
 #! format: on
 
         trials = OrderedCollections.OrderedDict()

--- a/ext/benchmark_utils.jl
+++ b/ext/benchmark_utils.jl
@@ -48,8 +48,8 @@ function tabulate_summary(summary; n_calls_per_step)
     )
 end
 
-get_trial(f::Nothing, args, name, device; with_cu_prof = :bprofile, trace = false) = nothing
-function get_trial(f, args, name, device; with_cu_prof = :bprofile, trace = false)
+get_trial(f::Nothing, args, name, device; with_cu_prof = :bprofile, trace = false, crop = false) = nothing
+function get_trial(f, args, name, device; with_cu_prof = :bprofile, trace = false, crop = false)
     f(args...) # compile first
     b = if device isa ClimaComms.CUDADevice
         BenchmarkTools.@benchmarkable CUDA.@sync $f($(args)...)
@@ -65,7 +65,9 @@ function get_trial(f, args, name, device; with_cu_prof = :bprofile, trace = fals
         else
             CUDA.@profile trace = trace f(args...)
         end
-        println(p)
+        io = IOContext(stdout, :crop => crop)
+        show(io, p)
+        println()
     end
     println()
     return trial


### PR DESCRIPTION
This PR allows us to not crop the profile table in `benchmark_step`.