### PR TITLE
Allow benchmark_step to benchmark targeted functions

### DIFF
--- a/ext/benchmark_utils.jl
+++ b/ext/benchmark_utils.jl
@@ -48,8 +48,8 @@ function tabulate_summary(summary; n_calls_per_step)
     )
 end
 
-get_trial(f::Nothing, args, name, device; with_cu_prof = :bprofile, trace = false, crop = false) = nothing
-function get_trial(f, args, name, device; with_cu_prof = :bprofile, trace = false, crop = false)
+get_trial(f::Nothing, args, name; device, with_cu_prof = :bprofile, trace = false, crop = false) = nothing
+function get_trial(f, args, name; device, with_cu_prof = :bprofile, trace = false, crop = false)
     f(args...) # compile first
     b = if device isa ClimaComms.CUDADevice
         BenchmarkTools.@benchmarkable CUDA.@sync $f($(args)...)


### PR DESCRIPTION
This will allow us to target specific benchmarks. We could eliminate the percentage table, but I think that's more work than it's worth. Instead I've added a warning print that the percentage column is only based off of functions specified in the `only` argument.