### PR TITLE
Add horizontal cropping to perf table

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ClimaTimeSteppers"
 uuid = "595c0a79-7f3d-439a-bc5a-b232dc3bde79"
 authors = ["Climate Modeling Alliance"]
-version = "0.7.30"
+version = "0.7.31"
 
 [deps]
 ClimaComms = "3a4d1b5c-c61d-41fd-a00a-5873ba7a1b0d"

--- a/ext/ClimaTimeSteppersBenchmarkToolsExt.jl
+++ b/ext/ClimaTimeSteppersBenchmarkToolsExt.jl
@@ -53,6 +53,7 @@ const allowed_names =
         with_cu_prof::Symbol = :bfrofile, # [:bprofile, :profile]
         trace::Bool = false,
         crop::Bool = false,
+        hcrop::Union{Nothing, Int} = nothing,
         only::Union{Nothing, Vector{String}} = nothing,
     )
 
@@ -62,6 +63,7 @@ Benchmark a DistributedODEIntegrator given:
  - `with_cu_prof`, `:profile` or `:bprofile`, to call `CUDA.@profile` or `CUDA.@bprofile` respectively.
  - `trace`, Bool passed to `CUDA.@profile` (see CUDA docs)
  - `crop`, Bool indicating whether or not to crop the `CUDA.@profile` printed table.
+ - `hcrop`, Number of horizontal characters to include in the table before cropping.
  - `only, list of functions to benchmarks (benchmark all by default)
 
 `only` may contain:
@@ -81,6 +83,7 @@ function CTS.benchmark_step(
     with_cu_prof::Symbol = :bprofile,
     trace::Bool = false,
     crop::Bool = false,
+    hcrop::Union{Nothing, Int} = nothing,
     only::Union{Nothing, Vector{String}} = nothing,
 )
     (; u, p, t, dt, sol, alg) = integrator
@@ -96,7 +99,7 @@ function CTS.benchmark_step(
         @. X = u
         @. Xlim = u
         trials₀ = OrderedCollections.OrderedDict()
-        kwargs = (; device, with_cu_prof, trace, crop)
+        kwargs = (; device, with_cu_prof, trace, crop, hcrop)
 #! format: off
         maybe_push!(trials₀, "Wfact", wfact_fun(integrator), (W, u, p, dt, t), kwargs, only)
         maybe_push!(trials₀, "ldiv!", LA.ldiv!, (X, W, u), kwargs, only)


### PR DESCRIPTION
See https://github.com/ronisbr/PrettyTables.jl/issues/11#issuecomment-2145550354. As a result, we see virtually no information in the method name.

I think 168 should be a good number for buildkite, but the default should probably just use `displaysize`, as this works nice locally.