### PR TITLE
Turn on verbose convergence tests

### DIFF
--- a/docs/src/plotting_utils.jl
+++ b/docs/src/plotting_utils.jl
@@ -113,7 +113,7 @@ function verify_convergence(
     average_function = array -> norm(array) / sqrt(length(array)),
     average_function_str = "RMS",
     only_endpoints = false,
-    verbose = false,
+    verbose = true,
 )
     (; test_name, t_end, linear_implicit, analytic_sol) = test_case
     prob = test_case.split_prob


### PR DESCRIPTION
Docs failures are hard to debug.