### PR TITLE
Fix consistency of precomputed quantities for Rosenbrock

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ClimaTimeSteppers"
 uuid = "595c0a79-7f3d-439a-bc5a-b232dc3bde79"
 authors = ["Climate Modeling Alliance"]
-version = "0.7.32"
+version = "0.7.33"
 
 [deps]
 ClimaComms = "3a4d1b5c-c61d-41fd-a00a-5873ba7a1b0d"

--- a/docs/src/plotting_utils.jl
+++ b/docs/src/plotting_utils.jl
@@ -143,6 +143,7 @@ function verify_convergence(
     float_str(x) = @sprintf "%.4f" x
     pow_str(x) = "10^{$(@sprintf "%.1f" log10(x))}"
     function si_str(x)
+        x in (0, Inf, -Inf, NaN) && return string(x)
         exponent = floor(Int, log10(x))
         mantissa = x / 10.0^exponent
         return "$(float_str(mantissa)) \\times 10^{$exponent}"

--- a/src/solvers/rosenbrock.jl
+++ b/src/solvers/rosenbrock.jl
@@ -146,9 +146,13 @@ function step_u!(int, cache::RosenbrockCache{Nstages}) where {Nstages}
             U .+= A[i, j] .* k[j]
         end
 
+        # NOTE: post_implicit! is a misnomer
         if !isnothing(post_implicit!)
-            # NOTE: post_implicit! is a misnomer
-            post_implicit!(U, p, t + αi * dt)
+            # We update p on every stage but the first, and at the end of each
+            # timestep. Since the first stage is unchanged from the end of the
+            # previous timestep, this order of operations ensures that p is
+            # always consistent with the state, including between timesteps.
+            (i != 1) && post_implicit!(U, p, t + αi * dt)
         end
 
         if !isnothing(T_imp!)
@@ -197,6 +201,7 @@ function step_u!(int, cache::RosenbrockCache{Nstages}) where {Nstages}
     end
 
     dss!(u, p, t + dt)
+    post_implicit!(u, p, t + dt)
     return nothing
 end
 


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
<!--- One sentence to describe the purpose of this PR, refer to any linked issues:
#14 -- this will link to issue 14
Closes #2 -- this will automatically close issue 2 on PR merge
-->
This PR fixes a bug in the Rosenbrock timestepper that results in inconsistent precomputed quantities in ClimaAtmos.

Since the first stage of an `s`-stage timestepping scheme is typically the same as the final state of the previous timestep, we can chose to update `p` based on each of the stages `U_1--U_s`, or we can choose to update it based on the stages `U_2--U_s` and the final state `u`. The Rosenbrock timestepper is currently using the first option, whereas the ARK methods use the second option. With the first option, the value of `p` between timesteps is not consistent with the value of `u`, since it did not get updated when `u` was computed and still has the value from `U_s` (for FSAL timesteppers, `u = U_s`, but SSPKnoth is not FSAL). The second option fixes this issue, so the Rosenbrock timestepper needs to be updated to use it.

Also, our computation for `p` modifies the state by updating the boundary face values of `u_3`. With the first option, only the intermediate stages get updated, and the final state `u` is left with unconstrained boundary face values of `u_3`. This has resulted in nonsensical surface velocities in ClimaAtmos simulations with topography (these velocities do not seem to be used for any tendencies or diagnostics, which is why they have gone unnoticed for some time).

<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [x] I have read and checked the items on the review checklist.
