### PR TITLE
Fix type instabilities in Rosenbrock `step_u!`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ClimaTimeSteppers"
 uuid = "595c0a79-7f3d-439a-bc5a-b232dc3bde79"
 authors = ["Climate Modeling Alliance"]
-version = "0.7.33"
+version = "0.7.34"
 
 [deps]
 ClimaComms = "3a4d1b5c-c61d-41fd-a00a-5873ba7a1b0d"


### PR DESCRIPTION
This PR fixes some type instabilities, and makes the `RosenbrockTableau` fields concretely typed.

Found in https://buildkite.com/clima/climaatmos-ci/builds/20495#0191e6bb-8f3f-4c0e-b74c-27bb4170f8da (where I've added `@test_opt SciMLBase.step!(integrator)` to the ClimaAtmos driver).