### PR TITLE
Allow mixed types for Rosenbrock coeffs

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ClimaTimeSteppers"
 uuid = "595c0a79-7f3d-439a-bc5a-b232dc3bde79"
 authors = ["Climate Modeling Alliance"]
-version = "0.7.34"
+version = "0.7.35"
 
 [deps]
 ClimaComms = "3a4d1b5c-c61d-41fd-a00a-5873ba7a1b0d"

--- a/src/solvers/rosenbrock.jl
+++ b/src/solvers/rosenbrock.jl
@@ -123,7 +123,6 @@ function step_u!(int, cache::RosenbrockCache{Nstages}) where {Nstages}
     tgrad! = isnothing(T_imp!) ? nothing : T_imp!.tgrad
 
     (; post_explicit!, post_implicit!, dss!) = int.sol.prob.f
-    tT = typeof(t)
 
     # TODO: This is only valid when Γ[i, i] is constant, otherwise we have to
     # move this in the for loop
@@ -142,8 +141,8 @@ function step_u!(int, cache::RosenbrockCache{Nstages}) where {Nstages}
         # Reset tendency
         fill!(fU, 0)
 
-        αi = sum(α[i, 1:(i - 1)]; init = zero(tT))::tT
-        γi = sum(Γ[i, 1:i]; init = zero(tT))::tT
+        αi = sum(α[i, 1:(i - 1)]; init = zero(eltype(α)))
+        γi = sum(Γ[i, 1:i]; init = zero(eltype(Γ)))
 
         U .= u
         for j in 1:(i - 1)


### PR DESCRIPTION
I forgot that we always use Float64 for our coefficients,, so the main branch is breaking for float32 simulations. This PR fixes this by allowing for type promotions. Inference should still be fixed by the previous PR, the main issue there was not having `init`, and lack of concrete types in the tableau.

I tested this locally and it works, merging.