### PR TITLE
Add Bool assertion in callback loop

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ClimaTimeSteppers"
 uuid = "595c0a79-7f3d-439a-bc5a-b232dc3bde79"
 authors = ["Climate Modeling Alliance"]
-version = "0.7.36"
+version = "0.7.37"
 
 [deps]
 ClimaComms = "3a4d1b5c-c61d-41fd-a00a-5873ba7a1b0d"

--- a/src/integrators.jl
+++ b/src/integrators.jl
@@ -247,7 +247,7 @@ function __step!(integrator)
     # apply callbacks
     discrete_callbacks = integrator.callback.discrete_callbacks
     for (ncb, callback) in enumerate(discrete_callbacks)
-        if callback.condition(integrator.u, integrator.t, integrator)
+        if callback.condition(integrator.u, integrator.t, integrator)::Bool
             NVTX.@range "Callback $ncb of $(length(discrete_callbacks))" color = colorant"yellow" begin
                 callback.affect!(integrator)
             end


### PR DESCRIPTION
To (hopefully) fix:

```
JET-test failed at /central/scratch/esm/slurm-buildkite/climaatmos-ci/20549/climaatmos-ci/perf/jet_report_nfailures.jl:53
--
  | Expression: #= /central/scratch/esm/slurm-buildkite/climaatmos-ci/20549/climaatmos-ci/perf/jet_report_nfailures.jl:53 =# JET.@test_opt SciMLBase.step!(integrator)
  | ═════ 1 possible error found ═════
  | ┌ step!(integrator::ClimaTimeSteppers.DistributedODEIntegrator{…}) @ ClimaTimeSteppers /central/scratch/esm/slurm-buildkite/climaatmos-ci/depot/default/packages/ClimaTimeSteppers/KGEKL/src/integrators.jl:203
  | │┌ __step!(integrator::ClimaTimeSteppers.DistributedODEIntegrator{…}) @ ClimaTimeSteppers /central/scratch/esm/slurm-buildkite/climaatmos-ci/depot/default/packages/ClimaTimeSteppers/KGEKL/src/integrators.jl:250
  | ││ runtime dispatch detected: %133::Any(%134::ClimaCore.Fields.FieldVector{Float32, @NamedTuple{c::ClimaCore.Fields.Field{…}, f::ClimaCore.Fields.Field{…}}}, %135::Float32, %126::ClimaTimeSteppers.DistributedODEIntegrator{…})::Any
  | │└────────────────────
```