### PR TITLE
Fix inference failure in callbacks

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ClimaTimeSteppers"
 uuid = "595c0a79-7f3d-439a-bc5a-b232dc3bde79"
 authors = ["Climate Modeling Alliance"]
-version = "0.7.37"
+version = "0.7.38"
 
 [deps]
 ClimaComms = "3a4d1b5c-c61d-41fd-a00a-5873ba7a1b0d"

--- a/perf/jet.jl
+++ b/perf/jet.jl
@@ -60,5 +60,5 @@ end
     JET.@test_opt CTS.step_u!(integrator, integrator.cache)
 
     CTS.__step!(integrator) # compile first, and make sure it runs
-    JET.@test_opt broken = true CTS.__step!(integrator)
+    JET.@test_opt CTS.__step!(integrator)
 end


### PR DESCRIPTION
This PR fixes the broken inference test for the callback loop. Closes #316 and #315.