### PR TITLE
Do not crop limiters table

### DIFF
--- a/docs/src/plotting_utils.jl
+++ b/docs/src/plotting_utils.jl
@@ -182,6 +182,7 @@ function limiter_summary(sol_dicts, algorithm_names)
             "2-Norm Error",
             "∞-Norm Error",
         ],
+        crop = :none,
         body_hlines = collect(3:3:(length(table_rows) - 1)),
         formatters = ft_printf("%.4e"),
     )


### PR DESCRIPTION
This PR is an attempt to prevent the limiters summary table from being cropped:

<img width="887" alt="Screenshot 2024-11-12 at 10 14 35 PM" src="https://github.com/user-attachments/assets/db66227e-dca8-4056-8674-f7adcb5a02a9">
