### PR TITLE
Conditionally load convergence utils

### DIFF
--- a/test/convergence_lsrk.jl
+++ b/test/convergence_lsrk.jl
@@ -6,10 +6,12 @@ using ClimaTimeSteppers, LinearAlgebra, Test
 import PrettyTables
 import SciMLBase
 
-include(joinpath(@__DIR__, "convergence_orders.jl"))
-include(joinpath(@__DIR__, "convergence_utils.jl"))
-include(joinpath(@__DIR__, "utils.jl"))
-include(joinpath(@__DIR__, "problems.jl"))
+if !@isdefined(IntegratorTestCase)
+    include(joinpath(@__DIR__, "convergence_orders.jl"))
+    include(joinpath(@__DIR__, "convergence_utils.jl"))
+    include(joinpath(@__DIR__, "utils.jl"))
+    include(joinpath(@__DIR__, "problems.jl"))
+end
 
 @testset "LSRK convergence" begin
     dts = 0.5 .^ (4:7)

--- a/test/tabulate_convergence_orders_imex_ark.jl
+++ b/test/tabulate_convergence_orders_imex_ark.jl
@@ -6,10 +6,12 @@ using ClimaTimeSteppers, LinearAlgebra, Test
 import PrettyTables
 import SciMLBase
 
-include(joinpath(@__DIR__, "convergence_orders.jl"))
-include(joinpath(@__DIR__, "convergence_utils.jl"))
-include(joinpath(@__DIR__, "utils.jl"))
-include(joinpath(@__DIR__, "problems.jl"))
+if !@isdefined(IntegratorTestCase)
+    include(joinpath(@__DIR__, "convergence_orders.jl"))
+    include(joinpath(@__DIR__, "convergence_utils.jl"))
+    include(joinpath(@__DIR__, "utils.jl"))
+    include(joinpath(@__DIR__, "problems.jl"))
+end
 
 function tabulate_convergence_orders_imex_ark()
     tabs = [

--- a/test/tabulate_convergence_orders_imex_ssp.jl
+++ b/test/tabulate_convergence_orders_imex_ssp.jl
@@ -6,10 +6,12 @@ using ClimaTimeSteppers, LinearAlgebra, Test
 import PrettyTables
 import SciMLBase
 
-include(joinpath(@__DIR__, "convergence_orders.jl"))
-include(joinpath(@__DIR__, "convergence_utils.jl"))
-include(joinpath(@__DIR__, "utils.jl"))
-include(joinpath(@__DIR__, "problems.jl"))
+if !@isdefined(IntegratorTestCase)
+    include(joinpath(@__DIR__, "convergence_orders.jl"))
+    include(joinpath(@__DIR__, "convergence_utils.jl"))
+    include(joinpath(@__DIR__, "utils.jl"))
+    include(joinpath(@__DIR__, "problems.jl"))
+end
 
 function tabulate_convergence_orders_imex_ssp()
     tabs = [SSP222, SSP322, SSP332, SSP333, SSP433]

--- a/test/tabulate_convergence_orders_multirate.jl
+++ b/test/tabulate_convergence_orders_multirate.jl
@@ -6,10 +6,12 @@ using ClimaTimeSteppers, LinearAlgebra, Test
 import PrettyTables
 import SciMLBase
 
-include(joinpath(@__DIR__, "convergence_orders.jl"))
-include(joinpath(@__DIR__, "convergence_utils.jl"))
-include(joinpath(@__DIR__, "utils.jl"))
-include(joinpath(@__DIR__, "problems.jl"))
+if !@isdefined(IntegratorTestCase)
+    include(joinpath(@__DIR__, "convergence_orders.jl"))
+    include(joinpath(@__DIR__, "convergence_utils.jl"))
+    include(joinpath(@__DIR__, "utils.jl"))
+    include(joinpath(@__DIR__, "problems.jl"))
+end
 
 function tabulate_convergence_orders_multirate()
 

--- a/test/tabulate_convergence_orders_rosenbrock.jl
+++ b/test/tabulate_convergence_orders_rosenbrock.jl
@@ -6,10 +6,12 @@ using ClimaTimeSteppers, LinearAlgebra, Test
 import PrettyTables
 import SciMLBase
 
-include(joinpath(@__DIR__, "convergence_orders.jl"))
-include(joinpath(@__DIR__, "convergence_utils.jl"))
-include(joinpath(@__DIR__, "utils.jl"))
-include(joinpath(@__DIR__, "problems.jl"))
+if !@isdefined(IntegratorTestCase)
+    include(joinpath(@__DIR__, "convergence_orders.jl"))
+    include(joinpath(@__DIR__, "convergence_utils.jl"))
+    include(joinpath(@__DIR__, "utils.jl"))
+    include(joinpath(@__DIR__, "problems.jl"))
+end
 
 function tabulate_convergence_orders_rosenbrock()
     tabs = [SSPKnoth]


### PR DESCRIPTION
The test suite on GHA has a bunch of errors:

```julia
WARNING: Method definition kwcall(NamedTuple{names, T} where T<:Tuple where names, typeof(##232.test_convergence_order!), Any, Any) in module ##232 at /home/runner/work/ClimaTimeSteppers.jl/ClimaTimeSteppers.jl/test/convergence_utils.jl:57 overwritten on the same line (check for duplicate calls to `include`).
WARNING: Method definition kwcall(NamedTuple{names, T} where T<:Tuple where names, typeof(##232.test_convergence_order!), Any, Any, Any) in module ##232 at /home/runner/work/ClimaTimeSteppers.jl/ClimaTimeSteppers.jl/test/convergence_utils.jl:57 overwritten on the same line (check for duplicate calls to `include`).
WARNING: Method definition pass_conv(Any, Any) in module ##232 at /home/runner/work/ClimaTimeSteppers.jl/ClimaTimeSteppers.jl/test/convergence_utils.jl:73 overwritten on the same line (check for duplicate calls to `include`).
WARNING: Method definition fail_conv(Any, Any) in module ##232 at /home/runner/work/ClimaTimeSteppers.jl/ClimaTimeSteppers.jl/test/convergence_utils.jl:74 overwritten on the same line (check for duplicate calls to `include`).
WARNING: Method definition super_conv(Any, Any) in module ##232 at /home/runner/work/ClimaTimeSteppers.jl/ClimaTimeSteppers.jl/test/convergence_utils.jl:75 overwritten on the same line (check for duplicate calls to `include`).
WARNING: Method definition convergence_order_results(Any, Any) in module ##232 at /home/runner/work/ClimaTimeSteppers.jl/ClimaTimeSteppers.jl/test/convergence_utils.jl:79 overwritten on the same line (check for duplicate calls to `include`).
```
due to re-including utility files (build [here](https://github.com/CliMA/ClimaTimeSteppers.jl/actions/runs/11821908144/job/32937723732)).

This PR conditionally loads based on if `IntegratorTestCase` is defined.