### PR TITLE
Increase n-steps (decrease dt) in 2D heat eq

### DIFF
--- a/docs/src/dev/report_gen_alg.jl
+++ b/docs/src/dev/report_gen_alg.jl
@@ -89,7 +89,7 @@ let # Convergence
     export_convergence_results(
         alg_name,
         climacore_2Dheat_test_cts(Float64),
-        600;
+        700;
         num_steps_scaling_factor = 4,
         numerical_reference_algorithm_name = ARS343(),
     )


### PR DESCRIPTION
Found in this [build](https://buildkite.com/clima/climatimesteppers-ci/builds/1396#0193286a-2d3d-4ac1-9527-1afd2effd19f).

I think we previously did not decrease the timestep because it was prohibitively expensive (because the jobs are serially executed). Now that we run them in parallel, we can try to fix this without CI times exploding.

I'm tempted to remove all the soft-fails with this PR, so that we are required to address every failing job.