### PR TITLE
Remake problem manually during multirate init

### DIFF
--- a/src/solvers/multirate.jl
+++ b/src/solvers/multirate.jl
@@ -24,16 +24,32 @@ struct MultirateCache{OC, II}
     innerinteg::II
 end
 
+"""
+    cts_remake(prob::DiffEqBase.AbstractODEProblem; f::DiffEqBase.AbstractODEFunction)
+
+Remake an ODE problem with a new function `f`.
+"""
+function cts_remake(prob::DiffEqBase.AbstractODEProblem; f::DiffEqBase.AbstractODEFunction)
+    return DiffEqBase.ODEProblem{DiffEqBase.isinplace(prob)}(
+        f,
+        prob.u0,
+        prob.tspan,
+        prob.p,
+        prob.problem_type;
+        prob.kwargs...,
+    )
+end
+
 function init_cache(prob::DiffEqBase.AbstractODEProblem, alg::Multirate; dt, fast_dt, kwargs...)
 
     @assert prob.f isa DiffEqBase.SplitFunction
 
     # subproblems
-    outerprob = DiffEqBase.remake(prob; f = prob.f.f2)
+    outerprob = cts_remake(prob; f = prob.f.f1)
     outercache = init_cache(outerprob, alg.slow)
 
     innerfun = init_inner(prob, outercache, dt)
-    innerprob = DiffEqBase.remake(prob; f = innerfun)
+    innerprob = cts_remake(prob; f = innerfun)
     innerinteg = DiffEqBase.init(innerprob, alg.fast; dt = fast_dt, kwargs...)
     return MultirateCache(outercache, innerinteg)
 end


### PR DESCRIPTION




Alternatively, the compat for SciMLBase can be restricted. I opened PR #343 to test CI with that.
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
fixes #341 

SciMLBase.remake is called twice during the cache initialization for a problem with the multirate alg.

SciMLBase changed the way remake(::AbstractODEProblem,...) works in 2.68.0. Previously, if the `f` kwarg was an AbstractODEFunction, the problem was remade with f directly as its function. After 2.68.0, remake(::AbstractODEProblem) calls a new remake method with `f` and `prob.f` as arguments. This new function returns an AbstarctSciMLFunction of the same type and properties as `prob.f`.


## To-do
<!---  list of proposed tasks in the PR, move to "Content" on completion 
- Proposed task
-->


## Content
This commit replicates the behavior of DiffEqBase.remake on the provided arguments before the change.


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [x] I have read and checked the items on the review checklist.
