### PR TITLE
Remove check for number in tstops_and_saveat_heaps

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,10 @@ ClimaTimeSteppers.jl Release Notes
 
 Main
 -------
+v0.8.2
+- ![][badge-💥breaking] If saveat is a number, then it does not automatically expand to `tspan[1]:saveat:tspan[2]`. To fix this, update
+`saveat`, which is a keyword in the integrator, to be an array. For example, if `saveat` is a scalar, replace it with
+`[tspan[1]:saveat:tspan[2]..., tspan[2]]` to achieve the same behavior as before.
 
 v0.7.18
 -------

--- a/docs/src/tutorials/diffusion.jl
+++ b/docs/src/tutorials/diffusion.jl
@@ -190,9 +190,9 @@ prob = SciMLBase.ODEProblem(
 # We use SSPKnoth for this example
 algo = ClimaTimeSteppers.RosenbrockAlgorithm(ClimaTimeSteppers.tableau(ClimaTimeSteppers.SSPKnoth()));
 
-# And here is the integrator, where we set `saveat = dt` to save a snapshot of
+# And here is the integrator, where we set `saveat = t0:dt:t_end` to save a snapshot of
 # the solution at every timestep.
-integrator = SciMLBase.init(prob, algo; dt, saveat = dt);
+integrator = SciMLBase.init(prob, algo; dt, saveat = t0:dt:t_end);
 
 ## Solution and visualization
 #

--- a/src/integrators.jl
+++ b/src/integrators.jl
@@ -66,7 +66,7 @@ end
 
 
 # helper function for setting up min/max heaps for tstops and saveat
-function tstops_and_saveat_heaps(t0, tf, tstops, saveat)
+function tstops_and_saveat_heaps(t0, tf, tstops, saveat = [])
     FT = typeof(tf)
     ordering = tf > t0 ? DataStructures.FasterForward : DataStructures.FasterReverse
 
@@ -74,18 +74,9 @@ function tstops_and_saveat_heaps(t0, tf, tstops, saveat)
     tstops = [filter(t -> t0 < t < tf || tf < t < t0, tstops)..., tf]
     tstops = DataStructures.BinaryHeap{FT, ordering}(tstops)
 
-    if isnothing(saveat)
-        saveat = [t0, tf]
-    elseif saveat isa Number
-        saveat > zero(saveat) || error("saveat value must be positive")
-        saveat = tf > t0 ? saveat : -saveat
-        saveat = [t0:saveat:tf..., tf]
-    else
-        # We do not need to filter saveat like tstops because the saving
-        # callback will ignore any times that are not between t0 and tf.
-        saveat = collect(saveat)
-    end
-    saveat = DataStructures.BinaryHeap{FT, ordering}(saveat)
+    isnothing(saveat) && (saveat = [t0, tf])
+
+    saveat = DataStructures.BinaryHeap{FT, ordering}(collect(saveat))
 
     return tstops, saveat
 end

--- a/test/integrator.jl
+++ b/test/integrator.jl
@@ -70,11 +70,9 @@ include("problems.jl")
 
             # testing non-interpolated saving (OrdinaryDiffEq interpolates when saving)
             (false, (; saveat = save_dt_times), misaligned_saving_times),
-            (false, (; saveat = save_dt), [misaligned_saving_times..., tf]),
 
             # testing tstops (tstops remove the need for interpolation when saving)
             (true, (; saveat = save_dt_times, tstops = save_dt_times), save_dt_times),
-            (true, (; saveat = save_dt, tstops = save_dt_times), [save_dt_times..., tf]),
 
             # testing add_tstops! and add_saveat!
             (true, (; saveat = [tf], callback = adding_callback), [save_dt_times..., tf]),
@@ -136,9 +134,6 @@ end
             ((;), (; erase_sol = false), [t0, tf, t0′, tf′]),
             ((;), (; saveat = save_dt_times′, tstops = save_dt_times′), save_dt_times′),
             ((; saveat = save_dt_times′, tstops = save_dt_times′), (;), save_dt_times′),
-            ((;), (; saveat = save_dt, tstops = save_dt_times′), [save_dt_times′..., tf′]),
-            ((; saveat = save_dt, tstops = save_dt_times′), (;), [save_dt_times′..., tf′]),
-            ((; saveat = save_dt, tstops = all_times), (; erase_sol = false), all_times),
         )
             integrator = init(deepcopy(prob), alg; dt, init_kwargs...)
             @test !@any_reltype(integrator, (UnionAll, DataType))


### PR DESCRIPTION
We do this because for long runs, you might want to change the type of time (e.g. ITime) which may not be a number.

