### PR TITLE
Swap DSS and T_imp approximation

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ClimaTimeSteppers"
 uuid = "595c0a79-7f3d-439a-bc5a-b232dc3bde79"
 authors = ["Climate Modeling Alliance"]
-version = "0.8.0"
+version = "0.8.1"
 
 [deps]
 ClimaComms = "3a4d1b5c-c61d-41fd-a00a-5873ba7a1b0d"

--- a/src/solvers/imex_ssprk.jl
+++ b/src/solvers/imex_ssprk.jl
@@ -79,6 +79,7 @@ function step_u!(integrator, cache::IMEXSSPRKCache)
     for i in 1:s
         t_exp = t + dt * c_exp[i]
         t_imp = t + dt * c_imp[i]
+        dtγ = dt * a_imp[i, i]
 
         if i == 1
             @. U_exp = u
@@ -106,20 +107,16 @@ function step_u!(integrator, cache::IMEXSSPRKCache)
 
         if isnothing(T_imp!) || iszero(a_imp[i, i])
             i ≠ 1 && cache!(U, p, t_exp)
-            if !all(iszero, a_imp[:, i]) || !iszero(b_imp[i])
-                # If its coefficient is 0, T_imp[i] is being treated explicitly.
-                isnothing(T_imp!) || T_imp!(T_imp[i], U, p, t_imp)
-            end
         else # Implicit solve
             @assert !isnothing(newtons_method)
             i ≠ 1 && cache_imp!(U, p, t_imp)
             @. temp = U
             implicit_equation_residual! = (residual, Ui) -> begin
                 T_imp!(residual, Ui, p, t_imp)
-                @. residual = temp + dt * a_imp[i, i] * residual - Ui
+                @. residual = temp + dtγ * residual - Ui
             end
             implicit_equation_jacobian! = (jacobian, Ui) -> begin
-                T_imp!.Wfact(jacobian, Ui, p, dt * a_imp[i, i], t_imp)
+                T_imp!.Wfact(jacobian, Ui, p, dtγ, t_imp)
             end
             implicit_equation_cache! = Ui -> cache_imp!(Ui, p, t_imp)
             solve_newton!(
@@ -130,21 +127,23 @@ function step_u!(integrator, cache::IMEXSSPRKCache)
                 implicit_equation_jacobian!,
                 implicit_equation_cache!,
             )
-            if !all(iszero, a_imp[:, i]) || !iszero(b_imp[i])
-                # If T_imp[i] is being treated implicitly, ensure that it
-                # exactly satisfies the implicit equation before applying DSS.
-                @. T_imp[i] = (U - temp) / (dt * a_imp[i, i])
-            end
             dss!(U, p, t_imp)
             cache!(U, p, t_imp)
         end
 
         if !iszero(β[i])
-            if !isnothing(T_exp_T_lim!)
-                T_exp_T_lim!(T_lim, T_exp, U, p, t_exp)
+            isnothing(T_exp_T_lim!) || T_exp_T_lim!(T_lim, T_exp, U, p, t_exp)
+            isnothing(T_lim!) || T_lim!(T_lim, U, p, t_exp)
+            isnothing(T_exp!) || T_exp!(T_exp, U, p, t_exp)
+        end
+        if !all(iszero, a_imp[:, i]) || !iszero(b_imp[i])
+            if iszero(a_imp[i, i])
+                # If its coefficient is 0, T_imp[i] is being treated explicitly.
+                isnothing(T_imp!) || T_imp!(T_imp[i], U, p, t_imp)
             else
-                isnothing(T_lim!) || T_lim!(T_lim, U, p, t_exp)
-                isnothing(T_exp!) || T_exp!(T_exp, U, p, t_exp)
+                # If T_imp[i] is being treated implicitly, ensure that it
+                # exactly satisfies the implicit equation after applying DSS.
+                isnothing(T_imp!) || @. T_imp[i] = (U - temp) / dtγ
             end
         end
     end


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
<!--- One sentence to describe the purpose of this PR, refer to any linked issues:
#14 -- this will link to issue 14
Closes #2 -- this will automatically close issue 2 on PR merge
-->
This PR swaps the order of DSS and the approximation of `T_imp` to improve the stability of a test case in ClimaAtmos, and it bumps the minor version number.

In #352, I moved the approximation of `T_imp` to just before the second call to DSS, ensuring that the implicit tendency passed to future stages does not include any effects of DSS. This seemed like the correct choice at the time, but further testing with the ClimaAtmos longruns ([T_imp before DSS](https://buildkite.com/clima/climaatmos-gpulongruns/builds/479) vs [DSS before T_imp](https://buildkite.com/clima/climaatmos-gpulongruns/builds/481)) has shown that it is better to have DSS before the approximation of `T_imp`, so that the implicit tendency passed to future stages is always continuous.

<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [x] I have read and checked the items on the review checklist.
