### PR TITLE
Fix hard-coded ARS343, simplify code and add comments

### DIFF
--- a/src/solvers/imex_ark.jl
+++ b/src/solvers/imex_ark.jl
@@ -120,29 +120,28 @@ end
     has_T_exp(f) && fused_increment!(U, dt, a_exp, T_exp, Val(i))
     isnothing(T_imp!) || fused_increment!(U, dt, a_imp, T_imp, Val(i))
 
+    # Run the implicit solver, apply DSS, and update the cache. When γ == 0,
+    # the implicit solver does not need to be run. On stage i == 1, we do not
+    # need to apply DSS and update the cache because we did that at the end of
+    # the previous timestep.
     i ≠ 1 && dss!(U, p, t_exp)
-
     if isnothing(T_imp!) || iszero(a_imp[i, i])
         i ≠ 1 && cache!(U, p, t_exp)
-    else # Implicit solve
+    else
         @assert !isnothing(newtons_method)
         i ≠ 1 && cache_imp!(U, p, t_imp)
         @. temp = U
-        implicit_equation_residual! = (residual, Ui) -> begin
-            T_imp!(residual, Ui, p, t_imp)
-            @. residual = temp + dtγ * residual - Ui
+        implicit_equation_residual! = (residual, U′) -> begin
+            T_imp!(residual, U′, p, t_imp)
+            @. residual = temp + dtγ * residual - U′
         end
-        implicit_equation_jacobian! = (jacobian, Ui) -> begin
-            T_imp!.Wfact(jacobian, Ui, p, dtγ, t_imp)
-        end
-        implicit_equation_cache! = Ui -> cache_imp!(Ui, p, t_imp)
         solve_newton!(
             newtons_method,
             newtons_method_cache,
             U,
             implicit_equation_residual!,
-            implicit_equation_jacobian!,
-            implicit_equation_cache!,
+            (jacobian, U′) -> T_imp!.Wfact(jacobian, U′, p, dtγ, t_imp),
+            U′ -> cache_imp!(U′, p, t_imp),
         )
         dss!(U, p, t_imp)
         cache!(U, p, t_imp)
@@ -155,11 +154,12 @@ end
     end
     if !all(iszero, a_imp[:, i]) || !iszero(b_imp[i])
         if iszero(a_imp[i, i])
-            # If its coefficient is 0, T_imp[i] is being treated explicitly.
+            # When γ == 0, T_imp[i] is treated explicitly.
             isnothing(T_imp!) || T_imp!(T_imp[i], U, p, t_imp)
         else
-            # If T_imp[i] is being treated implicitly, ensure that it
-            # exactly satisfies the implicit equation after applying DSS.
+            # When γ != 0, T_imp[i] is treated implicitly, so it must satisfy
+            # the implicit equation. To ensure that T_imp[i] only includes the
+            # effect of applying DSS to T_imp!, U and temp must be DSSed.
             isnothing(T_imp!) || @. T_imp[i] = (U - temp) / dtγ
         end
     end


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
<!--- One sentence to describe the purpose of this PR, refer to any linked issues:
#14 -- this will link to issue 14
Closes #2 -- this will automatically close issue 2 on PR merge
-->
This PR fixes the hard-coded ARS343 timestepper, which I didn't update correctly in #352 and #356. (We should probably add convergence tests for it at some point.) It also simplifies the way we call Newton's method, and it adds some code comments to clarify how we are combining DSS, cache updates, and the implicit solver.

<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [x] I have read and checked the items on the review checklist.
